### PR TITLE
Added setup_staticmaps_from_raster 

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -42,6 +42,7 @@ Setup components
    WflowModel.setup_precip_forcing
    WflowModel.setup_temp_pet_forcing
    WflowModel.setup_constant_pars
+   WflowModel.setup_staticmaps_from_raster
 
 Attributes
 ----------
@@ -148,6 +149,7 @@ Setup components
    WflowSedimentModel.setup_gauges
    WflowSedimentModel.setup_areamap
    WflowSedimentModel.setup_constant_pars
+   WflowSedimentModel.setup_staticmaps_from_raster
 
 Attributes
 ----------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,7 @@ Unreleased
 Added
 -----
 - Parameters for landuse esa_worlcover. `PR #111 <https://github.com/Deltares/hydromt_wflow/pull/111>`_
+- New **setup_staticmaps_from_raster** method. `PR #128 <https://github.com/Deltares/hydromt_wflow/issues/111>`_
 
 Changed
 -------

--- a/docs/user_guide/sediment_model_setup.rst
+++ b/docs/user_guide/sediment_model_setup.rst
@@ -58,6 +58,8 @@ a specific method see its documentation.
       - Setup area map from vector data to save wflow outputs for specific area.
     * - :py:func:`~WflowSedimentModel.setup_constant_pars`
       - Setup constant parameter maps.
+    * - :py:func:`~WflowModel.setup_staticmaps_from_raster`
+      -  Setup staticmaps from raster to add parameters from direct data.
 
 
 .. _model_components_sed:

--- a/docs/user_guide/wflow_model_setup.rst
+++ b/docs/user_guide/wflow_model_setup.rst
@@ -62,6 +62,8 @@ a specific method see its documentation.
       -  Setup gridded reference evapotranspiration forcing at model resolution.
     * - :py:func:`~WflowModel.setup_constant_pars`
       -  Setup constant parameter maps for all active model cells.
+    * - :py:func:`~WflowModel.setup_staticmaps_from_raster`
+      -  Setup staticmaps from raster to add parameters from direct data.
 
 
 .. _model_components:

--- a/tests/test_model_methods.py
+++ b/tests/test_model_methods.py
@@ -1,0 +1,55 @@
+"""Unit tests for hydromt_wflow methods and workflows"""
+
+import pytest
+from os.path import join, dirname, abspath
+import warnings
+import pdb
+from hydromt_wflow.wflow import WflowModel
+
+import logging
+
+TESTDATADIR = join(dirname(abspath(__file__)), "data")
+EXAMPLEDIR = join(dirname(abspath(__file__)), "..", "examples")
+
+
+def test_setup_staticmaps():
+    logger = logging.getLogger(__name__)
+    # read model from examples folder
+    root = join(EXAMPLEDIR, "wflow_piave_subbasin")
+
+    # Initialize model and read results
+    mod = WflowModel(root=root, mode="r", data_libs="artifact_data", logger=logger)
+
+    # Tests on setup_staticmaps_from_raster
+    mod.setup_staticmaps_from_raster(
+        raster_fn="merit_hydro",
+        reproject_method="average",
+        variables=["elevtn"],
+        wflow_variables=["input.vertical.altitude"],
+        fill_method="nearest",
+    )
+    assert "elevtn" in mod.staticmaps
+    assert mod.get_config("input.vertical.altitude") == "elevtn"
+
+    mod.setup_staticmaps_from_raster(
+        raster_fn="globcover",
+        reproject_method="mode",
+        wflow_variables=["input.vertical.landuse"],
+    )
+    assert "globcover" in mod.staticmaps
+    assert mod.get_config("input.vertical.landuse") == "globcover"
+
+    # Test on exceptions
+    with pytest.raises(ValueError, match="Length of variables"):
+        mod.setup_staticmaps_from_raster(
+            raster_fn="merit_hydro",
+            reproject_method="average",
+            variables=["elevtn", "lndslp"],
+            wflow_variables=["input.vertical.altitude"],
+        )
+    with pytest.raises(ValueError, match="variables list is not provided"):
+        mod.setup_staticmaps_from_raster(
+            raster_fn="merit_hydro",
+            reproject_method="average",
+            wflow_variables=["input.vertical.altitude"],
+        )


### PR DESCRIPTION
Can be used to solve #128 
This method allows to add wflow variables from direct raster data (eg USLE parameter or altitude, ksatver etc.)
The function also allows to update the toml file in order to still get ready to run model with the new staticmaps.