### PR TITLE
Update examples installation

### DIFF
--- a/examples/README.rst
+++ b/examples/README.rst
@@ -20,16 +20,65 @@ The first step is to install HydroMT-Wflow and the other Python dependencies in 
 see the **Install HydroMT-Wflow in a new environment** section in the
 `installation guide <https://deltares.github.io/hydromt_wflow/latest/getting_started/installation.html>`_
 
+To run the notebooks, you need to install additional dependencies that are jupyterlab to
+run the notebooks and cartopy for some plots. To install these packages in your existing
+hydromt-wflow environment, do (these packages are also available in conda-forge):
 
-2 - Download the content of the HydroMT github repository
-*********************************************************
-To run the examples locally, you will need to download the content of the examples folder in the HydroMT-Wflow repository.
-You can  do a `manual download <https://github.com/Deltares/hydromt_wflow/archive/refs/heads/main.zip>`_
-and extract the content of the downloaded ZIP folder **or** clone the repository locally (this requires git):
+.. code-block:: console
+
+  $ conda activate hydromt-wflow
+  $ pip install jupyterlab
+  $ pip install cartopy
+
+
+2 - Download the content of the examples and notebooks
+******************************************************
+To run the examples locally, you will need to download the content of the hydromt_wflow repository.
+You have two options:
+
+  1. Download and unzip the examples manually
+  2. Clone the hydromt_wflow GitHub repository
+
+.. warning::
+
+  Depending on your installed version of hydromt and hydromt_wflow, you will need to download the correct versions of the examples.
+  To check the version of hydromt_wflow that you have installed, do:
+
+  .. code-block:: console
+
+    $ hydromt --models
+
+    model plugins:
+     - dflowfm (hydromt_wflow 0.4.1)
+    generic models (hydromt 0.9.1)
+     - grid_model
+     - vector_model
+     - mesh_model
+     - network_model
+
+In the examples above, we see version 0.4.1 of hydromt_wflow is installed and version 0.9.1 of hydromt.
+
+**Option 1: manual download and unzip**
+
+To manually download the examples on Windows, do (!replace with your own hydromt_wflow version!):
+
+.. code-block:: console
+
+  $ curl https://github.com/Deltares/hydromt_wflow/archive/refs/tags/v0.4.1.zip -O -L
+  $ tar -xf v0.4.1.zip
+  $ ren hydromt_wflow-0.4.1 hydromt_wflow
+
+You can also download, unzip and rename manually if you prefer, rather than using the windows command prompt.
+
+**Option 2: cloning the hydromt_wflow repository**
+
+For git users, you can also get the examples by cloning the hydromt_wflow github repository and checkout the version
+you have installed:
 
 .. code-block:: console
 
   $ git clone https://github.com/Deltares/hydromt_wflow.git
+  $ git checkout v0.4.1
 
 3 - Running the examples
 ************************

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -57,7 +57,8 @@ You have two options:
     $ hydromt --models
 
     model plugins:
-     - dflowfm (hydromt_wflow 0.4.1)
+     - wflow (hydromt_wflow 0.4.1)
+     - wflow_sediment (hydromt_wflow 0.4.1)
     generic models (hydromt 0.9.1)
      - grid_model
      - vector_model

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -30,6 +30,14 @@ hydromt-wflow environment, do (these packages are also available in conda-forge)
   $ pip install jupyterlab
   $ pip install cartopy
 
+.. note::
+
+  To run the example notebook using pcraster, you will also need to install it from
+  conda-forge (not available on pypi):
+
+  .. code-block:: console
+
+    $ conda install -c conda-forge pcraster
 
 2 - Download the content of the examples and notebooks
 ******************************************************

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,6 @@ doc = [
 examples = [
     "jupyterlab",
     "cartopy",
-    "matplotlib-base",
     "notebook",
 ]
 


### PR DESCRIPTION
## Issue addressed
Fixes #206 

## Explanation
I think the installation was already updated but the examples not fully (installing jupyter and downloading the correct version of the examples).
I also do not think we need matplotlib-base in the [examples] install list as matplotlib is already installed and matplotlib-base is not installable with pip.

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed

## Additional notes
In hydromt core or the delft3dfm plugin, I recommend installing from pypi like so:
pip install "hydromt[slim]"
This avoids that people need to manually add libraries in [extra] and [examples] one by one or clone the github repository.
It does not work at the moment because of the matplolib-base library in [examples] (which I now removed) and the pcraster library in [extra]. 
I think an easy way to install and run the examples would be nice. For this, maybe we could move the pcraster library in another list than extra? Else we could also add gwwapi, hydroengine and pyet in the examples list instead?
