### PR TITLE
update wflow build notebook

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -36,7 +36,7 @@ Setup components
    WflowModel.setup_glaciers
    WflowModel.setup_lulcmaps
    WflowModel.setup_laimaps
-   WflowModel.setup_ksathorfarc
+   WflowModel.setup_ksathorfrac
    WflowModel.setup_rootzoneclim
    WflowModel.setup_soilmaps
    WflowModel.setup_outlets
@@ -101,8 +101,6 @@ General methods
    WflowModel.read_grid
    WflowModel.write_grid
    WflowModel.clip_grid
-   WflowModel.read_staticmaps_pcr
-   WflowModel.write_staticmaps_pcr
 
    WflowModel.set_geoms
    WflowModel.read_geoms

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -22,7 +22,8 @@ Changed
 
 Fixed
 -----
-- Wrong dtype for wflow_subcatch map. PR #247
+- Wrong dtype for wflow_subcatch map. PR #247,
+- Removed building a wflow model without a config file in the build notebook.
 
 v0.5.0 (February 2024)
 ======================

--- a/examples/build_model.ipynb
+++ b/examples/build_model.ipynb
@@ -144,7 +144,7 @@
    "id": "a5062c03",
    "metadata": {},
    "source": [
-    "Once we have prepared our data catalog and model build settings file, we are ready to ask HydroMT to build our Wflow model. This can be done from the command line and here is an example for the Northern part of the Piave basin in Italy:"
+    "Once we have prepared our data catalog and model build settings file, we are ready to ask HydroMT to build our Wflow model. Building the model can be done from the command line. Down below is an example for the Northern part of the Piave basin in Italy:"
    ]
   },
   {

--- a/examples/build_model.ipynb
+++ b/examples/build_model.ipynb
@@ -72,43 +72,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f286fccb",
-   "metadata": {},
-   "source": [
-    "### Setup Wflow model base layers "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "closed-excerpt",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# NOTE: copy this line (without !) to your shell for more direct feedback\n",
-    "# NOTE: as of hydromt version 0.7.0 the region argument is optional and should be preceded by -r or --region\n",
-    "# NOTE: the resolution argument has been removed since hydromt v0.7.0 and can now only be configured from the configuration file under the setup_basemap header\n",
-    "!hydromt build wflow \"./wflow_test_base\" -r \"{'subbasin': [12.2051, 45.8331], 'strord': 4, 'bounds': [11.70, 45.35, 12.95, 46.70]}\" -v -d artifact_data"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "id": "cb9d0032",
-   "metadata": {},
-   "source": [
-    "The example above means the following: run **hydromt build** with:\n",
-    "\n",
-    "* `wflow` : i.e. build a Wflow model\n",
-    "* `./wflow_test_base` : output model folder\n",
-    "* `-r \"{'subbasin': [12.2051, 45.8331], 'strord': 4, 'bounds': [11.70, 45.35, 12.95, 46.70]}\"` : derive a subbasin with its outlet at the given x,y coordinates and within the given bounds [xmin, ymin, xmax, ymax] (WGS84) snapped to a river with minimum stream order (strord) of 4. All *REGION* options are described in the [docs](https://deltares.github.io/hydromt/latest/user_guide/model_region)\n",
-    "* `-vv` : give some extra verbosity (2 * v) to display feedback on screen. Now debug messages are provided.\n",
-    "\n",
-    "NOTE: As we did not specify a model configuration, only the base maps (topography and hydrography) have been setup using default parameters. To build a complete model we need the use a configuraton file."
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "ebd31242",
    "metadata": {},
    "source": [
@@ -177,6 +140,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "a5062c03",
+   "metadata": {},
+   "source": [
+    "Once we have prepared our data catalog and model build settings file, we are ready to ask HydroMT to build our Wflow model. This can be done from the command line and here is an example for the Northern part of the Piave basin in Italy:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "hundred-trailer",
@@ -194,8 +165,14 @@
    "id": "b31e92d2",
    "metadata": {},
    "source": [
-    "With this example we build a complete Wflow model including forcing. Compared to the previous **hydromt build** we have added:\n",
-    "* `-i wflow_build.yml` : setup configuration file including all components to build and their arguments"
+    "With this example we build a complete Wflow model including forcing. The example means the following: run **hydromt build** with:\n",
+    "\n",
+    "* `wflow` : i.e. build a Wflow model\n",
+    "* `./wflow_test_full` : output model folder\n",
+    "* `-r \"{'subbasin': [12.2051, 45.8331], 'strord': 4, 'bounds': [11.70, 45.35, 12.95, 46.70]}\"` : derive a subbasin with its outlet at the given x,y coordinates and within the given bounds [xmin, ymin, xmax, ymax] (WGS84) snapped to a river with minimum stream order (strord) of 4. All *REGION* options are described in the [docs](https://deltares.github.io/hydromt/latest/user_guide/model_region)\n",
+    "* `-i wflow_build.yml` : setup configuration file including all components to build and their arguments\n",
+    "* `-d artifact_data`: data catalog to use. Here `artifact_data` which contains a global data extract for Northern Italy for demo purposes.\n",
+    "* `-vv` : give some extra verbosity (2 * v) to display feedback on screen. Now debug messages are provided.\n"
    ]
   },
   {

--- a/hydromt_wflow/wflow.py
+++ b/hydromt_wflow/wflow.py
@@ -2707,12 +2707,12 @@ Run setup_soilmaps first"
 
         There are two methods to connect models:
 
-        - `subbasin_area`: 
+        - `subbasin_area`:
             creates subcatchments linked to the 1d river based
             on an area threshold (area_max) for the subbasin size. With this method,
             if a tributary is larger than the `area_max`, it will be connected to
             the 1d river directly.
-        - `nodes`: 
+        - `nodes`:
             subcatchments are derived based on the 1driver nodes (used as
             gauges locations). With this method, large tributaries can also be derived
             separately using the `add_tributaries` option and adding a `area_max`

--- a/hydromt_wflow/wflow.py
+++ b/hydromt_wflow/wflow.py
@@ -2707,11 +2707,13 @@ Run setup_soilmaps first"
 
         There are two methods to connect models:
 
-            - `subbasin_area`: creates subcatchments linked to the 1d river based
+        - `subbasin_area`: 
+            creates subcatchments linked to the 1d river based
             on an area threshold (area_max) for the subbasin size. With this method,
             if a tributary is larger than the `area_max`, it will be connected to
             the 1d river directly.
-            - `nodes`: subcatchments are derived based on the 1driver nodes (used as
+        - `nodes`: 
+            subcatchments are derived based on the 1driver nodes (used as
             gauges locations). With this method, large tributaries can also be derived
             separately using the `add_tributaries` option and adding a `area_max`
             threshold for the tributaries.

--- a/hydromt_wflow/workflows/connect.py
+++ b/hydromt_wflow/workflows/connect.py
@@ -29,11 +29,13 @@ def wflow_1dmodel_connection(
 
     There are two methods to connect models:
 
-        - "subbasin_area": creates subcatchments linked to the 1d river based on an
+    - `subbasin_area`: 
+        creates subcatchments linked to the 1d river based on an
         area threshold (area_max) for the subbasin size. With this method, if a
         tributary is larger than the area_max, it will be connected to the 1d river
         directly.
-        - "nodes": subcatchments are derived based on the 1driver nodes (used as gauges
+    - `nodes`: 
+        subcatchments are derived based on the 1driver nodes (used as gauges
         locations). With this method, large tributaries can also be derived separately
         using the add_tributaries option and adding a area_max threshold for the
         tributaries.

--- a/hydromt_wflow/workflows/connect.py
+++ b/hydromt_wflow/workflows/connect.py
@@ -29,12 +29,12 @@ def wflow_1dmodel_connection(
 
     There are two methods to connect models:
 
-    - `subbasin_area`: 
+    - `subbasin_area`:
         creates subcatchments linked to the 1d river based on an
         area threshold (area_max) for the subbasin size. With this method, if a
         tributary is larger than the area_max, it will be connected to the 1d river
         directly.
-    - `nodes`: 
+    - `nodes`:
         subcatchments are derived based on the 1driver nodes (used as gauges
         locations). With this method, large tributaries can also be derived separately
         using the add_tributaries option and adding a area_max threshold for the


### PR DESCRIPTION
## Issue addressed
Fixes #256 

## Explanation
We removed default merit_hydro value in setup_basemaps so the example of building a model without suppliying a config file does not work anymore.
The behavior is anyway not common and will be deprecated in hydromt v1 so I now removed that part of the example.

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed

