### PR TITLE
Bugfix when reading mapping table in lai lulc workflow

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,7 +16,7 @@ Added
 
 Fixed
 -----
-- Wrong dtype for columns when reading a mapping table in **setup_laimaps_from_lulc_mapping** . PR #287
+- Wrong dtype for columns when reading a mapping table in **setup_laimaps_from_lulc_mapping** . PR #290
 
 v0.6.0 (7 June 2024)
 ====================

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,10 @@ Added
 -----
 - To be Added
 
+Fixed
+-----
+- Wrong dtype for columns when reading a mapping table in **setup_laimaps_from_lulc_mapping** . PR #287
+
 v0.6.0 (7 June 2024)
 ====================
 Copious amounts of new features and fixes!

--- a/hydromt_wflow/workflows/landuse.py
+++ b/hydromt_wflow/workflows/landuse.py
@@ -283,7 +283,7 @@ def lai_from_lulc_mapping(
         Dataset with LAI values for each month.
     """
     months = np.arange(1, 13)
-    df.columns = [int(col) if col.isdigit() else col for col in df.columns]
+    df.columns = [int(col) if str(col).isdigit() else col for col in df.columns]
     # Map the monthly LAI values to the landuse map
     ds_lai = landuse(
         da=da,

--- a/hydromt_wflow/workflows/landuse.py
+++ b/hydromt_wflow/workflows/landuse.py
@@ -283,6 +283,7 @@ def lai_from_lulc_mapping(
         Dataset with LAI values for each month.
     """
     months = np.arange(1, 13)
+    df.columns = [int(col) if col.isdigit() else col for col in df.columns]
     # Map the monthly LAI values to the landuse map
     ds_lai = landuse(
         da=da,


### PR DESCRIPTION
## Issue addressed
Fixes #289

## Explanation
An error was raised because the columns 1 to 12 could not be found. This is caused by reading them as a string. This is solved by checking if there are digit columns and converting them to integers. This has been tested with a Wflow model for which a mapping table was created with `setup_lulcmaps`, and which is read by `setup_laimaps_from_lulc_mapping` in `lai_mapping_fn`.

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [X] Tests & pre-commit hooks pass
- [x] Updated documentation if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
