### PR TITLE
add a test to build model using direct conda forge install

### DIFF
--- a/.github/workflows/test_conda_forge.yml
+++ b/.github/workflows/test_conda_forge.yml
@@ -1,10 +1,11 @@
 name: Test conda forge release
 
 on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+  schedule:
+  # At 00:00 UTC every Monday
+    - cron: "0 0 * * 1"
+  # on demand
+  workflow_dispatch:
 
 jobs:
   Test:

--- a/.github/workflows/test_conda_forge.yml
+++ b/.github/workflows/test_conda_forge.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Install test dependencies
         run: |
-          mamba install -c conda-forge pytest pytest-cov pytest-mock
+          mamba install -c conda-forge pytest pytest-cov pytest-mock pytest-timeout
           pip install gwwapi
 
       - name: Conda info
@@ -52,4 +52,4 @@ jobs:
          conda list
 
       - name: Run model build Tests
-        run: python -m pytest --verbose tests/test_model_class.py::test_build_model
+        run: python -m pytest --verbose tests/test_model_class.py::test_model_build

--- a/.github/workflows/test_conda_forge.yml
+++ b/.github/workflows/test_conda_forge.yml
@@ -1,0 +1,55 @@
+name: Test conda forge release
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  Test:
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest" ] #, "macos-latest", "windows-latest"]
+        python-version: ['3.11']
+        include:
+        - os: ubuntu-latest
+          label: linux-64
+          prefix: /usr/share/miniconda3/envs/hydromt_wflow
+
+    name: ${{ matrix.label }} - py${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    concurrency:
+      group: ${{ github.workflow }}-${{ matrix.python-version }}-${{ github.ref }}
+      cancel-in-progress: true
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+          mamba-version: "*"
+          channels: conda-forge,defaults
+          channel-priority: true
+          activate-environment: hydromt-wflow
+
+      - name: Install hydromt_wflow
+        run: mamba install -c conda-forge hydromt_wflow
+
+      - name: Install test dependencies
+        run: |
+          mamba install -c conda-forge pytest pytest-cov pytest-mock
+          pip install gwwapi
+
+      - name: Conda info
+        run: |
+         conda info
+         conda list
+
+      - name: Run model build Tests
+        run: python -m pytest --verbose tests\\test_model_class.py

--- a/.github/workflows/test_conda_forge.yml
+++ b/.github/workflows/test_conda_forge.yml
@@ -52,4 +52,4 @@ jobs:
          conda list
 
       - name: Run model build Tests
-        run: python -m pytest --verbose tests\\test_model_class.py
+        run: python -m pytest --verbose tests/test_model_class.py::test_build_model

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "geopandas>=0.10",
     "hydromt>=0.9.4,<0.11",
     "netcdf4",
-    "numpy",
+    "numpy>=1.23, <2",      # max version 2 while we wait for hydromt core to update
     "pandas",
     "pyflwdir>=0.5.7",
     "pyproj",
@@ -23,7 +23,7 @@ dependencies = [
     "scipy",
     "shapely",
     "toml",
-    "xarray",
+    "xarray<=2024.3.0",     # pin xarray to avoid issues with time resampling and NaN interpolation
 ]
 requires-python = ">=3.9"
 readme = "README.rst"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,7 +49,11 @@ def example_sediment_model():
 
 @pytest.fixture()
 def example_models(example_wflow_model, example_sediment_model):
-    models = {"wflow": example_wflow_model, "wflow_sediment": example_sediment_model}
+    models = {
+        "wflow": example_wflow_model,
+        "wflow_sediment": example_sediment_model,
+        "wflow_simple": None,
+    }
     return models
 
 
@@ -68,8 +72,19 @@ def sediment_ini():
 
 
 @pytest.fixture()
-def example_inis(wflow_ini, sediment_ini):
-    inis = {"wflow": wflow_ini, "wflow_sediment": sediment_ini}
+def wflow_simple_ini():
+    config = join(dirname(abspath(__file__)), "..", "examples", "wflow_build.yml")
+    opt = parse_config(config)
+    return opt
+
+
+@pytest.fixture()
+def example_inis(wflow_ini, sediment_ini, wflow_simple_ini):
+    inis = {
+        "wflow": wflow_ini,
+        "wflow_sediment": sediment_ini,
+        "wflow_simple": wflow_simple_ini,
+    }
     return inis
 
 

--- a/tests/test_model_class.py
+++ b/tests/test_model_class.py
@@ -13,7 +13,11 @@ from hydromt_wflow.wflow_sediment import WflowSedimentModel
 TESTDATADIR = join(dirname(abspath(__file__)), "data")
 EXAMPLEDIR = join(dirname(abspath(__file__)), "..", "examples")
 
-_supported_models = {"wflow": WflowModel, "wflow_sediment": WflowSedimentModel}
+_supported_models = {
+    "wflow": WflowModel,
+    "wflow_sediment": WflowSedimentModel,
+    "wflow_simple": WflowModel,
+}
 
 
 def _compare_wflow_models(mod0, mod1):
@@ -126,9 +130,10 @@ def test_model_build(tmpdir, model, example_models, example_inis):
     mod1.read()
     # get reference model
     mod0 = example_models[model]
-    mod0.read()
-    # compare models
-    _compare_wflow_models(mod0, mod1)
+    if mod0 is not None:
+        mod0.read()
+        # compare models
+        _compare_wflow_models(mod0, mod1)
 
 
 def test_model_clip(tmpdir, example_wflow_model, clipped_wflow_model):

--- a/tests/test_model_class.py
+++ b/tests/test_model_class.py
@@ -96,10 +96,11 @@ def _compare_wflow_models(mod0, mod1):
 @pytest.mark.parametrize("model", list(_supported_models.keys()))
 def test_model_class(model, example_models):
     mod = example_models[model]
-    mod.read()
-    # run test_model_api() method
-    non_compliant_list = mod._test_model_api()
-    assert len(non_compliant_list) == 0
+    if mod is not None:
+        mod.read()
+        # run test_model_api() method
+        non_compliant_list = mod._test_model_api()
+        assert len(non_compliant_list) == 0
 
 
 @pytest.mark.timeout(300)  # max 5 min


### PR DESCRIPTION
## Issue addressed
Fixes #287

## Explanation

I investigated why the error did not show up in our tests. There is two reasons for it:

- installing hydromt_wflow from conda-forge results in different packages being installed than installing from an environment file even if all the dependencies listed are the same and version controls are the same. For example, installing from conda-forge gives hydromt 0.9.4 and xarray 2024.9.0 while installing from the environment file gives hydromt 0.10.0 and xarray 2024.3.0
- in our tests, we also build a model with too coarse resolution for this specific error to show. If we use the settings of the piave as in the jupyter notebooks (which is the first thing external user try) rather than the test, then the error showed up. 

So I decided to create a new test workflow where we can check if the easy conda forge install of hydromt-wflow is still able to build models. It will allow us to flag earlier broken conda-foge release but unfortunately if it broken, the only to get the test green again will be to do a new release of hydromt-wflow on conda-forge.

In the meantime, I put a max version on xarray (and numpy) in the pyproject toml and will do the same in the conda forge release. Problem is, I wont be able to test before we actually release on conda forge.

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
