### PR TITLE
add method for KsatVer vegetation based on paper Bonetti et al (2021)

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -44,6 +44,7 @@ Setup components
    WflowModel.setup_other_demand
    WflowModel.setup_irrigation
    WflowModel.setup_ksathorfrac
+   WflowModel.setup_ksatver_vegetation
    WflowModel.setup_rootzoneclim
    WflowModel.setup_soilmaps
    WflowModel.setup_outlets

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -263,6 +263,7 @@ Wflow workflows
    workflows.lai_from_lulc_mapping
    workflows.add_paddy_to_landuse
    workflows.ksathorfrac
+   workflows.ksatver_vegetation
    workflows.soilgrids
    workflows.soilgrids_sediment
    workflows.soilgrids_brooks_corey

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,7 +11,7 @@ Unreleased
 
 Added
 -----
--
+- **setup_ksatver_vegetation**: method to calculate KsatVer_vegetation to account for biologically-enhanced soil structure in KsatVer.
 
 Changed
 -------

--- a/docs/user_guide/wflow_model_setup.rst
+++ b/docs/user_guide/wflow_model_setup.rst
@@ -58,6 +58,8 @@ a specific method see its documentation.
       - This component derives several (layered) soil parameters based on a database with physical soil properties using available point-scale (pedo)transfer functions (PTFs) from literature with upscaling rules to ensure flux matching across scales.
     * - :py:func:`~WflowModel.setup_ksathorfrac`
       - This component prepares ksathorfrac from existing ksathorfrac data.
+    * - :py:func:`~WflowModel.setup_ksatver_vegetation`
+      - This component prepares ksatver from soil and vegetation parameters.
     * - :py:func:`~WflowModel.setup_rootzoneclim`
       - This component derives an estimate of the rooting depth from hydroclimatic data (as an alternative from the look-up table). The method can be applied for current conditions and future climate change conditions.
     * - :py:func:`~WflowModel.setup_outlets`

--- a/hydromt_wflow/wflow.py
+++ b/hydromt_wflow/wflow.py
@@ -2166,21 +2166,19 @@ Select the variable to use for ksathorfrac using 'variable' argument."
         self.logger.info("Modifying ksatver based on vegetation characteristics")
 
         # open soil dataset to get sand percentage
-        dsin = self.data_catalog.get_rasterdataset(soil_fn, geom=self.region, buffer=2)
-        sndppt = dsin["sndppt_sl1"]
+        sndppt = self.data_catalog.get_rasterdataset(
+            soil_fn, geom=self.region, buffer=2, variables=["sndppt_sl1"]
+        )
 
         # in function get_ksatver_vegetation KsatVer should be provided in mm/d
         KSatVer_vegetation = workflows.ksatver_vegetation(
-            self,
-            KsatVer=self.grid["KsatVer"],
+            ds_like=self.grid,
             sndppt=sndppt,
-            LAI=self.grid["LAI"],
             alfa=alfa,
             beta=beta,
         )
 
         map_name = "KsatVer_vegetation"
-        KSatVer_vegetation.name = map_name
 
         # add to grid
         self.set_grid(KSatVer_vegetation, map_name)

--- a/hydromt_wflow/wflow.py
+++ b/hydromt_wflow/wflow.py
@@ -2170,7 +2170,7 @@ Select the variable to use for ksathorfrac using 'variable' argument."
         sndppt = dsin["sndppt_sl1"]
 
         # in function get_ksatver_vegetation KsatVer should be provided in mm/d
-        KSatVer_vegetation = workflows.get_ksatver_vegetation(
+        KSatVer_vegetation = workflows.ksatver_vegetation(
             self,
             KsatVer=self.grid["KsatVer"],
             sndppt=sndppt,

--- a/hydromt_wflow/wflow.py
+++ b/hydromt_wflow/wflow.py
@@ -2138,15 +2138,18 @@ Select the variable to use for ksathorfrac using 'variable' argument."
         alfa: float = 4.5,
         beta: float = 5,
     ):
-        """Calculates KsatVer parameter values from vegetation in addition to soil characteristics \
-        to account for biologically-promoted soil structure and heterogeneities in natural landscapes \
-        based on the work of Bonetti et al. (2021) https://www.nature.com/articles/s43247-021-00180-0 
+        """Calculate KsatVer values from vegetation in addition to soil characteristics.
+
+        This allows to account for biologically-promoted soil structure and \
+        heterogeneities in natural landscapes based on the work of \
+        Bonetti et al. (2021) https://www.nature.com/articles/s43247-021-00180-0.
 
         This method requires to have run setup_soilgrids and setup_lai first.
 
         The following map is added to grid:
 
-        * **KsatVer_vegetation** map: saturated hydraulic conductivity considering vegetation characteristics [mm/d]
+        * **KsatVer_vegetation** map: saturated hydraulic conductivity considering \
+        vegetation characteristics [mm/d]
 
         Parameters
         ----------
@@ -2162,32 +2165,20 @@ Select the variable to use for ksathorfrac using 'variable' argument."
         """
         self.logger.info("Modifying ksatver based on vegetation characteristics")
 
+        # open soil dataset to get sand percentage
         dsin = self.data_catalog.get_rasterdataset(soil_fn, geom=self.region, buffer=2)
-        snd_ppt = dsin["sndppt_sl1"]
-        snd_ppt = snd_ppt.where(snd_ppt != snd_ppt._FillValue, np.nan)
-        # reproject to model resolution
-        snd_ppt = snd_ppt.raster.reproject_like(self.grid, method="average")
-        snd_ppt.raster.set_nodata(np.nan)
-        # interpolate to fill missing values
-        snd_ppt = snd_ppt.raster.interpolate_na("rio_idw")
-        # mask outside basin
-        snd_ppt = snd_ppt.where(self.grid["wflow_subcatch"] > 0)
+        sndppt = dsin["sndppt_sl1"]
 
-        # mean annual lai is required (see fig 1 in Bonetti et al. 2021)
-        LAI_mean = self.grid["LAI"].mean("time")
-        LAI_mean.raster.set_nodata(255.0)
-
-        # in function get_ksatver_vegetation KsatVer should be provided in cm/d
+        # in function get_ksatver_vegetation KsatVer should be provided in mm/d
         KSatVer_vegetation = workflows.get_ksatver_vegetation(
-            KsatVer=self.grid["KsatVer"] / 10,
-            sndppt=snd_ppt,
-            LAI=LAI_mean,
+            self,
+            KsatVer=self.grid["KsatVer"],
+            sndppt=sndppt,
+            LAI=self.grid["LAI"],
             alfa=alfa,
             beta=beta,
         )
 
-        # convert back from cm/d to mm/d
-        KSatVer_vegetation = KSatVer_vegetation * 10
         map_name = "KsatVer_vegetation"
         KSatVer_vegetation.name = map_name
 

--- a/hydromt_wflow/workflows/soilparams.py
+++ b/hydromt_wflow/workflows/soilparams.py
@@ -195,7 +195,7 @@ def get_ks_veg(KsatVer, sndppt, LAI, alfa=4.5, beta=5):
     return ks
 
 
-def get_ksatver_vegetation(self, KsatVer, sndppt, LAI, alfa=4.5, beta=5):
+def ksatver_vegetation(self, KsatVer, sndppt, LAI, alfa=4.5, beta=5):
     """
     Calculate saturated hydraulic conductivity based on soil and vegetation [mm/d].
 

--- a/tests/test_model_methods.py
+++ b/tests/test_model_methods.py
@@ -309,6 +309,28 @@ def test_setup_ksathorfrac(tmpdir, example_wflow_model):
     assert int(mean_val * 100) == 19991
 
 
+def test_setup_ksatver_vegetation(tmpdir, example_wflow_model):
+    # Read the modeldata
+    model = "wflow"
+    example_wflow_model.read()
+
+    # Build the map
+    example_wflow_model.setup_ksatver_vegetation(
+        soil_fn="soilgrids",
+    )
+
+    # Set the output directory
+    destination = str(tmpdir.join(model))
+    example_wflow_model.set_root(destination, mode="w")
+
+    # Check values
+    values = example_wflow_model.grid.KsatVer_vegetation.raster.mask_nodata()
+    max_val = values.max().values
+    mean_val = values.mean().values
+    assert int(max_val) == 4247
+    assert int(mean_val) == 1672
+
+
 def test_setup_lai(tmpdir, example_wflow_model):
     # Use vito and MODIS lai data for testing
     # Read LAI data

--- a/tests/test_model_methods.py
+++ b/tests/test_model_methods.py
@@ -310,18 +310,10 @@ def test_setup_ksathorfrac(tmpdir, example_wflow_model):
 
 
 def test_setup_ksatver_vegetation(tmpdir, example_wflow_model):
-    # Read the modeldata
-    model = "wflow"
-    example_wflow_model.read()
-
-    # Build the map
+    # Build the KsatVer vegetation map
     example_wflow_model.setup_ksatver_vegetation(
         soil_fn="soilgrids",
     )
-
-    # Set the output directory
-    destination = str(tmpdir.join(model))
-    example_wflow_model.set_root(destination, mode="w")
 
     # Check values
     values = example_wflow_model.grid.KsatVer_vegetation.raster.mask_nodata()


### PR DESCRIPTION
## Issue addressed
no issue

## Explanation
Within the FAO projects, we tested the approach of Bonetti to enhance the estimation of saturated hydraulic conductivity based on vegetation characteristics (here LAI). This method is now implemented in hydromt_wflow. The method requires to have run setup_LAI and setup_soilmaps first. A new map KsatVer_vegetation is created in the grid. 

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
