### PR TITLE
python 39 support

### DIFF
--- a/.github/workflows/test_stable.yml
+++ b/.github/workflows/test_stable.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest" ] #, "macos-latest", "windows-latest"]
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.10', '3.11']
         include:
         - os: ubuntu-latest
           label: linux-64

--- a/.github/workflows/test_stable.yml
+++ b/.github/workflows/test_stable.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest" ] #, "macos-latest", "windows-latest"]
-        python-version: ['3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11']
         include:
         - os: ubuntu-latest
           label: linux-64

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,17 +6,17 @@ All notable changes to this project will be documented in this page.
 The format is based on `Keep a Changelog`_, and this project adheres to
 `Semantic Versioning`_.
 
-v0.7.1 (22 January 2025)
+v0.7.1 (23 January 2025)
 ========================
-Small release to fix temporary support for python 3.9.
+Officially drop support for python 3.9.
 
 Added
 -----
 - **setup_ksatver_vegetation**: method to calculate KsatVer_vegetation to account for biologically-enhanced soil structure in KsatVer. PR #313
 
-Fixed
------
-- Support for python 3.9
+Deprecated
+----------
+- Support for python 3.9 (already not supported in previous releases).
 
 v0.7.0 (8 November 2024)
 ========================

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,20 +6,17 @@ All notable changes to this project will be documented in this page.
 The format is based on `Keep a Changelog`_, and this project adheres to
 `Semantic Versioning`_.
 
-Unreleased
-==========
+v0.7.1 (22 January 2025)
+========================
+Small release to fix temporary support for python 3.9.
 
 Added
 -----
-- **setup_ksatver_vegetation**: method to calculate KsatVer_vegetation to account for biologically-enhanced soil structure in KsatVer.
-
-Changed
--------
--
+- **setup_ksatver_vegetation**: method to calculate KsatVer_vegetation to account for biologically-enhanced soil structure in KsatVer. PR #313
 
 Fixed
 -----
--
+- Support for python 3.9
 
 v0.7.0 (8 November 2024)
 ========================

--- a/hydromt_wflow/__init__.py
+++ b/hydromt_wflow/__init__.py
@@ -1,6 +1,6 @@
 """hydroMT plugin for wflow models."""
 
-__version__ = "0.7.1dev0"
+__version__ = "0.7.1"
 
 from .naming import *
 from .utils import *

--- a/hydromt_wflow/pcrm.py
+++ b/hydromt_wflow/pcrm.py
@@ -5,6 +5,7 @@ import os
 import tempfile
 from os.path import basename, dirname, isdir, isfile, join
 from pathlib import Path
+from typing import Union
 
 import numpy as np
 import pandas as pd
@@ -187,7 +188,7 @@ def write_map(
 
 
 def read_staticmaps_pcr(
-    root: Path | str, crs: int = 4326, obj: object = None, **kwargs
+    root: Union[Path, str], crs: int = 4326, obj: object = None, **kwargs
 ):
     """
     Read pcraster staticmaps at <root/staticmaps> and parse to xarray.
@@ -196,7 +197,7 @@ def read_staticmaps_pcr(
 
     Parameters
     ----------
-    root : Path | str
+    root : Path, str
         Path to the root directory of the model. Assumes this folder contains a
         staticmaps folder with the pcraster maps.
     crs : int, optional
@@ -256,7 +257,7 @@ def read_staticmaps_pcr(
 
 def write_staticmaps_pcr(
     staticmaps: xr.Dataset,
-    root: Path | str,
+    root: Union[Path, str],
 ):
     """
     Write staticmaps at <root/staticmaps> in PCRaster maps format.
@@ -265,7 +266,7 @@ def write_staticmaps_pcr(
     ----------
     staticmaps : xr.Dataset
         Dataset with the staticmaps.
-    root : Path | str
+    root : Path, str
         Path to the root directory of the model. A staticmaps folder will be created
         in this folder with the pcraster maps.
     """

--- a/hydromt_wflow/wflow.py
+++ b/hydromt_wflow/wflow.py
@@ -2075,7 +2075,7 @@ a map for each of the wflow_sbm soil layers (n in total)
     def setup_ksathorfrac(
         self,
         ksat_fn: Union[str, xr.DataArray],
-        variable: str | None = None,
+        variable: Optional[str] = None,
         resampling_method: str = "average",
     ):
         """Set KsatHorFrac parameter values from a predetermined map.
@@ -2086,9 +2086,9 @@ or created by a third party/ individual.
 
         Parameters
         ----------
-        ksat_fn : str, optional
+        ksat_fn : str, xr.DataArray
             The identifier of the KsatHorFrac dataset in the data catalog.
-        variable : str | None, optional
+        variable : str, optional
             The variable name for the ksathorfrac map to use in ``ksat_fn`` in case \
 ``ksat_fn`` contains several variables. By default None.
         resampling_method : str, optional
@@ -4121,7 +4121,7 @@ Run setup_soilmaps first"
 
     def write_grid(
         self,
-        fn_out: Path | str = None,
+        fn_out: Optional[Union[Path, str]] = None,
     ):
         """
         Write grid to wflow static data file.
@@ -4132,7 +4132,7 @@ Run setup_soilmaps first"
 
         Parameters
         ----------
-        fn_out : Path | str, optional
+        fn_out : Path, str, optional
             Name or path to the outgoing grid file (including extension). This is the
             path/name relative to the root folder and if present the ``dir_input``
             folder.
@@ -4292,7 +4292,7 @@ Run setup_soilmaps first"
     def write_geoms(
         self,
         geoms_fn: str = "staticgeoms",
-        precision: int | None = None,
+        precision: Optional[int] = None,
     ):
         """
         Write geoms in GeoJSON format.
@@ -4306,6 +4306,9 @@ Run setup_soilmaps first"
         geoms_fn : str, optional
             Folder name/path where the static geometries are stored relative to the
             model root and ``dir_input`` if any. By default "staticgeoms".
+        precision : int, optional
+            Decimal precision to write the geometries. By default None to use 1 decimal
+            for projected crs and 6 for non-projected crs.
         """
         # to write use self.geoms[var].to_file()
         if not self._write:
@@ -4514,10 +4517,10 @@ change name input.path_forcing "
                     # only correct dates in toml for standard calendars:
                     if not hasattr(da.indexes["time"], "to_datetimeindex"):
                         times = da.time.values
-                        if (start < pd.to_datetime(times[0])) | (start not in times):
+                        if (start < pd.to_datetime(times[0])) or (start not in times):
                             start = pd.to_datetime(times[0])
                             correct_times = True
-                        if (end > pd.to_datetime(times[-1])) | (end not in times):
+                        if (end > pd.to_datetime(times[-1])) or (end not in times):
                             end = pd.to_datetime(times[-1])
                             correct_times = True
             # merge, process and write forcing

--- a/hydromt_wflow/workflows/demand.py
+++ b/hydromt_wflow/workflows/demand.py
@@ -1,7 +1,7 @@
 """Workflow for water demand."""
 
 import logging
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Union
 
 import geopandas as gpd
 import numpy as np
@@ -438,7 +438,7 @@ def classify_pixels(
     da_irr: xr.DataArray,
     da_crop_model: xr.DataArray,
     threshold: float,
-    nodata_value: float | int = -9999,
+    nodata_value: Union[float, int] = -9999,
 ):
     """Classifies pixels based on a (fractional) threshold.
 
@@ -453,7 +453,7 @@ def classify_pixels(
         Layer of the masked cropland in wflow model
     threshold: float
         Threshold above which pixels are classified as irrigated
-    nodata_value: float | int = -9999
+    nodata_value: float, int = -9999
         Value to be used for nodata
 
     Returns

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "toml",
     "xarray<=2024.3.0",     # pin xarray to avoid issues with time resampling and NaN interpolation
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 readme = "README.rst"
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -98,7 +98,7 @@ deps_not_in_conda = [
 
 [tool.black]
 line-length = 88
-target-version = ['py39']
+target-version = ['py310', 'py311']
 
 [tool.ruff]
 line-length = 88

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "pandas",
     "pyflwdir>=0.5.7",
     "pyproj",
-    "rioxarray",
+    "rioxarray<=0.17.0",    # pin because of xarray pin
     "scipy",
     "shapely",
     "toml",


### PR DESCRIPTION
## Issue addressed
Fixes #322 
See also: https://github.com/conda-forge/hydromt_wflow-feedstock/pull/21

## Explanation
Fix and small release to fix support for python 3.9. Will be dropped again when moving to hydromt v1 / wflow v1
> in the end, decided to drop support already to avoid additional testing for python 39

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
