### PR TITLE
remove duplicate dependency in pyproject.oml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,6 @@ test = [
   "pytest>=2.7.3",
   "pytest-timeout",
   "pytest-cov",
-  "pytest-timeout",
   "pytest-mock",
   "hydromt_wflow[dev, extra]",
 ]


### PR DESCRIPTION
## Explanation
Noticed `pytest-timeout` was specified in the `pyproject.toml` was specified twice, so I removed that. 

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
