### PR TITLE
Masking grid with subcatch on set instead of on write

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -25,7 +25,7 @@ Changed
 - **setup_soilmaps** [sediment]: additional parameters are prepared by the method (e.g. soil mean diameter, Govers transport capacity parameters).
 - **setup_constant_pars** [sediment]: added additional default values for sediment density and particle diameters.
 - **setup_riverbedsed** [sediment]: added option to derive Kodatie transport capacity parameters based on streamorder mapping.
-
+- Grid data is masked to subcatchment on `set_grid` now instead of on `write_grid` (#349)
 
 Fixed
 -----

--- a/hydromt_wflow/utils.py
+++ b/hydromt_wflow/utils.py
@@ -320,7 +320,7 @@ def get_grid_from_config(
 
 
 def mask_raster_from_layer(ds_grid: xr.Dataset, layer_name: str) -> xr.Dataset:
-    """Mask the data in the supplied grid based if the value in one of the layers.
+    """Mask the data in the supplied grid based on the value in one of the layers.
 
         This for example can be used to mask a grid based on subcatchment data.
         All data in the rest of the data variables in the dataset will be set to

--- a/hydromt_wflow/wflow.py
+++ b/hydromt_wflow/wflow.py
@@ -28,11 +28,10 @@ from hydromt.nodata import NoDataStrategy
 from pyflwdir import core_conversion, core_d8, core_ldd
 from shapely.geometry import box
 
-from hydromt_wflow.utils import mask_raster_from_layer
+from hydromt_wflow.utils import DATADIR, mask_raster_from_layer, read_csv_results
 
-from . import utils, workflows
+from . import workflows
 from .naming import HYDROMT_NAMES, WFLOW_NAMES
-from .utils import DATADIR
 
 __all__ = ["WflowModel"]
 
@@ -5082,9 +5081,7 @@ change name input.path_forcing "
             csv_fn.parent / output_dir / csv_fn.name if csv_fn is not None else csv_fn
         )
         if csv_fn is not None and isfile(csv_fn):
-            csv_dict = utils.read_csv_results(
-                csv_fn, config=self.config, maps=self.grid
-            )
+            csv_dict = read_csv_results(csv_fn, config=self.config, maps=self.grid)
             for key in csv_dict:
                 # Add to results
                 self.set_results(csv_dict[f"{key}"])

--- a/hydromt_wflow/wflow.py
+++ b/hydromt_wflow/wflow.py
@@ -4579,7 +4579,8 @@ Run setup_soilmaps first"
         """Add data to grid.
 
         All layers of grid must have identical spatial coordinates. This is an inherited
-        method from HydroMT-core's GridModel.set_grid with some fixes.
+        method from HydroMT-core's GridModel.set_grid with some fixes. If basin data is
+        available the grid will be masked to that upon setting.
 
         The first fix is when data with a time axis is being added. Since Wflow.jl
         v0.7.3, cyclic data at different lengths (12, 365, 366) is supported, as long as

--- a/tests/test_model_class.py
+++ b/tests/test_model_class.py
@@ -54,9 +54,11 @@ def _compare_wflow_models(mod0, mod1):
                     else f"{map1.dtype} instead of {map0.dtype}"
                 )
                 # Check on nodata
+                # hilariously np.nan == np.nan returns False, hence the additional check
                 err = (
                     err
                     if map0.raster.nodata == map1.raster.nodata
+                    or (np.isnan(map0.raster.nodata) and np.isnan(map1.raster.nodata))
                     else f"nodata {map1.raster.nodata} instead of \
 {map0.raster.nodata}; {err}"
                 )
@@ -66,7 +68,7 @@ def _compare_wflow_models(mod0, mod1):
                     # xy = map0.raster.idx_to_xy(np.where(notclose.ravel())[0])
                     # yxs = ", ".join([f"({y:.6f}, {x:.6f})" for x, y in zip(*xy)])
                     diff = (map0.values - map1.values)[notclose].mean()
-                    err = f"diff ({ncells:d} cells): {diff:.4f}; {err}"
+                    err = f"mean diff ({ncells:d} cells): {diff:.4f}; {err}"
                 invalid_maps[name] = err
     # invalid_map_str = ", ".join(invalid_maps)
     # assert (


### PR DESCRIPTION
## Issue addressed
Fixes #325 

## Explanation
Previously the grid was masked to the subcatch but only on write, meaning that if you read and wanted to do comparisons or make statistics you'd either have to do the masking manually, or you got wrong results. This is quite counterintuitive, so we moved the masking from the writing to the setting of the grid. 

Some extra contingencies had to be added since at the time of setting any grid, the subcatch might not exist (yet) or be not relevant, so in those cases we just do nothing. 

The clipping is applied again on the write to preserve previous behaviour. perhaps this is unnecessary, but I did it to be sure. This can easily be removed in necessary. 

I also fixed a new mistakes in the error reporting code I noticed while I was busy, but these are non-functional so it's not a big deal. 

## Checklist
- [ ] Updated tests or added new tests
- [ ] Branch is up to date with `main`
- [ ] Tests & pre-commit hooks pass
- [ ] Updated documentation if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
