### PR TITLE
wradlib interpolation_classes dict only created when wradlib is installed

### DIFF
--- a/hydromt_wflow/workflows/forcing.py
+++ b/hydromt_wflow/workflows/forcing.py
@@ -18,6 +18,7 @@ logger = logging.getLogger(__name__)
 
 __all__ = ["pet", "spatial_interpolation"]
 
+
 if HAS_WRADLIB:
     interpolation_classes = {
         "nearest": {"obj": wrl.ipol.Nearest, "args": None},

--- a/hydromt_wflow/workflows/forcing.py
+++ b/hydromt_wflow/workflows/forcing.py
@@ -18,17 +18,17 @@ logger = logging.getLogger(__name__)
 
 __all__ = ["pet", "spatial_interpolation"]
 
-
-interpolation_classes = {
-    "nearest": {"obj": wrl.ipol.Nearest, "args": None},
-    "linear": {"obj": wrl.ipol.Linear, "args": ["remove_missing"]},
-    "idw": {"obj": wrl.ipol.Idw, "args": ["nnearest", "p"]},
-    "ordinarykriging": {"obj": wrl.ipol.OrdinaryKriging, "args": ["cov", "nnearest"]},
-    "externaldriftkriging": {
-        "obj": wrl.ipol.ExternalDriftKriging,
-        "args": ["cov", "nnearest", "src_drift", "trg_drift", "remove_missing"],
-    },
-}
+if HAS_WRADLIB:
+    interpolation_classes = {
+        "nearest": {"obj": wrl.ipol.Nearest, "args": None},
+        "linear": {"obj": wrl.ipol.Linear, "args": ["remove_missing"]},
+        "idw": {"obj": wrl.ipol.Idw, "args": ["nnearest", "p"]},
+        "ordinarykriging": {"obj": wrl.ipol.OrdinaryKriging, "args": ["cov", "nnearest"]},
+        "externaldriftkriging": {
+            "obj": wrl.ipol.ExternalDriftKriging,
+            "args": ["cov", "nnearest", "src_drift", "trg_drift", "remove_missing"],
+        },
+    }
 
 
 def pet(

--- a/hydromt_wflow/workflows/forcing.py
+++ b/hydromt_wflow/workflows/forcing.py
@@ -24,7 +24,10 @@ if HAS_WRADLIB:
         "nearest": {"obj": wrl.ipol.Nearest, "args": None},
         "linear": {"obj": wrl.ipol.Linear, "args": ["remove_missing"]},
         "idw": {"obj": wrl.ipol.Idw, "args": ["nnearest", "p"]},
-        "ordinarykriging": {"obj": wrl.ipol.OrdinaryKriging, "args": ["cov", "nnearest"]},
+        "ordinarykriging": {
+            "obj": wrl.ipol.OrdinaryKriging,
+            "args": ["cov", "nnearest"],
+        },
         "externaldriftkriging": {
             "obj": wrl.ipol.ExternalDriftKriging,
             "args": ["cov", "nnearest", "src_drift", "trg_drift", "remove_missing"],

--- a/hydromt_wflow/workflows/forcing.py
+++ b/hydromt_wflow/workflows/forcing.py
@@ -7,32 +7,9 @@ import numpy as np
 import xarray as xr
 from hydromt.workflows.forcing import resample_time
 
-try:
-    import wradlib as wrl
-
-    HAS_WRADLIB = True
-except ImportError:
-    HAS_WRADLIB = False
-
 logger = logging.getLogger(__name__)
 
 __all__ = ["pet", "spatial_interpolation"]
-
-
-if HAS_WRADLIB:
-    interpolation_classes = {
-        "nearest": {"obj": wrl.ipol.Nearest, "args": None},
-        "linear": {"obj": wrl.ipol.Linear, "args": ["remove_missing"]},
-        "idw": {"obj": wrl.ipol.Idw, "args": ["nnearest", "p"]},
-        "ordinarykriging": {
-            "obj": wrl.ipol.OrdinaryKriging,
-            "args": ["cov", "nnearest"],
-        },
-        "externaldriftkriging": {
-            "obj": wrl.ipol.ExternalDriftKriging,
-            "args": ["cov", "nnearest", "src_drift", "trg_drift", "remove_missing"],
-        },
-    }
 
 
 def pet(
@@ -158,10 +135,27 @@ def spatial_interpolation(
     --------
     `wradlib.ipol.interpolate <https://docs.wradlib.org/en/latest/ipol.html#wradlib.ipol.interpolate>`
     """
-    if not HAS_WRADLIB:
+    try:
+        import wradlib as wrl
+    except ImportError:
         raise ModuleNotFoundError(
             "The wradlib package is required for spatial interpolation."
         )
+
+    # Specify wradlib interpolation classes
+    interpolation_classes = {
+        "nearest": {"obj": wrl.ipol.Nearest, "args": None},
+        "linear": {"obj": wrl.ipol.Linear, "args": ["remove_missing"]},
+        "idw": {"obj": wrl.ipol.Idw, "args": ["nnearest", "p"]},
+        "ordinarykriging": {
+            "obj": wrl.ipol.OrdinaryKriging,
+            "args": ["cov", "nnearest"],
+        },
+        "externaldriftkriging": {
+            "obj": wrl.ipol.ExternalDriftKriging,
+            "args": ["cov", "nnearest", "src_drift", "trg_drift", "remove_missing"],
+        },
+    }
 
     # Reproject forcing data to match the target CRS
     crs = ds_like.raster.crs


### PR DESCRIPTION
## Issue addressed
Fixes #354 

## Explanation
I added an if-statement to check if wradlib is installed and then create the interpolation_classes dict

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
