### PR TITLE
Preserve existing structure of toml config files on write

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -114,6 +114,8 @@ Changed
 -------
 - Individual methods like write_forcing will not longer write the config file if config settings get updated. Always call write_config as the last write method. PR #286
 - More uniform handling of the date typing when reading/writing dates from the wflow toml files. PR #286
+- ``Wflow._config`` is no longer a dictionary but a ``tomlkit.TOMLDocument`` to ensure structure of existing toml files are preserved upon write.
+  Due to this change we discourage users from modifying the config structure by hand, and instead rely on ``Wflow.set_config`` to avoid issues. (#387)
 
 Fixed
 -----

--- a/hydromt_wflow/data/wflow/wflow_sbm.toml
+++ b/hydromt_wflow/data/wflow/wflow_sbm.toml
@@ -30,9 +30,6 @@ path_output = "outstate/outstates.nc"
 path_forcing = "inmaps.nc"
 path_static  = "staticmaps.nc"
 
-# these empty headers are only to provide a grouping
-# groups present in the template config will
-# be used in the resulting config as well
 [input.static]
 
 [input.forcing]

--- a/hydromt_wflow/data/wflow/wflow_sbm.toml
+++ b/hydromt_wflow/data/wflow/wflow_sbm.toml
@@ -34,8 +34,6 @@ path_static  = "staticmaps.nc"
 
 [input.forcing]
 
-[input.vertical]
-
 [state.variables]
 vegetation_canopy_water__depth                     = "canopystorage"
 soil_water_sat-zone__depth                         = "satwaterdepth"

--- a/hydromt_wflow/data/wflow/wflow_sbm.toml
+++ b/hydromt_wflow/data/wflow/wflow_sbm.toml
@@ -1,44 +1,53 @@
 dir_output = "run_default"
 
 [time]
-calendar = "proleptic_gregorian"
-starttime = "2010-02-01T00:00:00"
-endtime = "2010-02-10T00:00:00"
-time_units = "days since 1900-01-01 00:00:00"
+calendar     = "proleptic_gregorian"
+starttime    = "2010-02-01T00:00:00"
+endtime      = "2010-02-10T00:00:00"
+time_units   = "days since 1900-01-01 00:00:00"
 timestepsecs = 86400
 
 [logging]
 loglevel = "info"
 
 [model]
-type = "sbm"
+type                         = "sbm"
 gravitational_snow_transport = true
-snow = true
-reinit = true
-reservoirs = false
-lakes = false
-glacier = false
-kin_wave_iteration = true
-kw_river_tstep = 900
-kw_land_tstep = 3600
+snow                         = true
+reinit                       = true
+reservoirs                   = false
+lakes                        = false
+glacier                      = false
+kin_wave_iteration           = true
+kw_river_tstep               = 900
+kw_land_tstep                = 3600
 
 [state]
-path_input = "instate/instates.nc"
+path_input  = "instate/instates.nc"
 path_output = "outstate/outstates.nc"
 
 [input]
 path_forcing = "inmaps.nc"
-path_static = "staticmaps.nc"
+path_static  = "staticmaps.nc"
+
+# these empty headers are only to provide a grouping
+# groups present in the template config will
+# be used in the resulting config as well
+[input.static]
+
+[input.forcing]
+
+[input.vertical]
 
 [state.variables]
-vegetation_canopy_water__depth = "canopystorage"
-soil_water_sat-zone__depth = "satwaterdepth"
-soil_layer_water_unsat-zone__depth = "ustorelayerdepth"
-soil_surface__temperature = "tsoil"
-"snowpack~dry__leq-depth" = "snow"
-"snowpack~liquid__depth" = "snowwater"
+vegetation_canopy_water__depth                     = "canopystorage"
+soil_water_sat-zone__depth                         = "satwaterdepth"
+soil_layer_water_unsat-zone__depth                 = "ustorelayerdepth"
+soil_surface__temperature                          = "tsoil"
+"snowpack~dry__leq-depth"                          = "snow"
+"snowpack~liquid__depth"                           = "snowwater"
 land_surface_water__instantaneous_volume_flow_rate = "q_land"
-land_surface_water__instantaneous_depth = "h_land"
-subsurface_water__volume_flow_rate = "ssf"
-river_water__instantaneous_volume_flow_rate = "q_river"
-river_water__instantaneous_depth = "h_river"
+land_surface_water__instantaneous_depth            = "h_land"
+subsurface_water__volume_flow_rate                 = "ssf"
+river_water__instantaneous_volume_flow_rate        = "q_river"
+river_water__instantaneous_depth                   = "h_river"

--- a/hydromt_wflow/naming.py
+++ b/hydromt_wflow/naming.py
@@ -916,11 +916,11 @@ def _create_hydromt_wflow_mapping(
     config_dict: dict,
 ) -> Tuple[dict, dict]:
     """
-    Create dictionnaries to convert from hydromt/Wflow names to staticmaps names.
+    Create dictionaries to convert from hydromt/Wflow names to staticmaps names.
 
-    The first dictionnary will be used to rename from hydromt convention
+    The first dictionary will be used to rename from hydromt convention
     name into name in staticmaps/forcing.
-    The second dictionnary will be used to link the right name
+    The second dictionary will be used to link the right name
     in staticmaps/forcing files to the right Wflow.jl variables in the toml file.
 
     Parameters
@@ -934,24 +934,24 @@ def _create_hydromt_wflow_mapping(
         the wflow variable names to be able to update the default names based on the
         config.
     config_dict : dict
-        Dictionnary of the current model config to update from the default name in
+        Dictionary of the current model config to update from the default name in
         staticmaps to the actual name in staticmaps.
 
     Returns
     -------
     mapping_hydromt : dict
-        Dictionnary of the mapping from hydromt names to staticmaps names.
+        Dictionary of the mapping from hydromt names to staticmaps names.
     mapping_wflow : dict
-        Dictionnary of the mapping from staticmaps names to Wflow variable names.
+        Dictionary of the mapping from staticmaps names to Wflow variable names.
     """
     wflow_version = "wflow_v1"  # variable version to use for Wflow.jl
 
-    # First dictionnary
+    # First dictionary
     # name_in_staticmaps : name_in_hydromt
     # Instantiate the mapping with default names (ie non wflow variables)
     mapping_inv = {v: k for k, v in hydromt_dict.items()}
 
-    # Second dictionnary
+    # Second dictionary
     wflow_names = dict()  # wflow_variable: name_in_staticmaps
 
     # Go through the wflow variables and add them if hydromt name is not None

--- a/hydromt_wflow/utils.py
+++ b/hydromt_wflow/utils.py
@@ -231,7 +231,7 @@ def _get_key_values_to_move(
 
 
 def _update_config_dict_with_value_keys(
-    keys_values_to_move: List[tuple[str, str]], data: dict[str, str]
+    keys_values_to_move: List[tuple[str, Any]], data: dict[str, str]
 ):
     for parent, value in keys_values_to_move:
         parents, parent = parent.rsplit(".", maxsplit=1)

--- a/hydromt_wflow/utils.py
+++ b/hydromt_wflow/utils.py
@@ -228,15 +228,15 @@ def get_config(
 
     Examples
     --------
-    >> # self.config = {'a': 1, 'b': {'c': {'d': 2}}}
+    >> config = {'a': 1, 'b': {'c': {'d': 2}}
 
-    >> get_config('a')
+    >> get_config('a', config)
     >> 1
 
-    >> get_config('b', 'c', 'd') # identical to get_config('b.c.d')
+    >> get_config('b', 'c', 'd', config) # identical to get_config('b.c.d')
     >> 2
 
-    >> get_config('b.c') # # identical to get_config('b','c')
+    >> get_config('b.c', config) # # identical to get_config('b','c')
     >> {'d': 2}
     """
     args = list(args)

--- a/hydromt_wflow/utils.py
+++ b/hydromt_wflow/utils.py
@@ -1,9 +1,10 @@
 """Some utilities from the Wflow plugin."""
 
 import logging
+from functools import reduce
 from os.path import abspath, dirname, join
 from pathlib import Path
-from typing import Dict
+from typing import Any, Dict, List
 
 import numpy as np
 import xarray as xr
@@ -198,17 +199,84 @@ of the config.
     return csv_dict
 
 
+def _update_nested_dict(key: str, value: Any, data: dict) -> None:
+    keys = key.split(".")
+    values_dict = reduce(lambda d, k: d.setdefault(k, {}), keys[:-1], data)[
+        keys[-1]
+    ].copy()
+    for k, v in values_dict.items():
+        if ".value" in k:
+            value.update({k: v})
+    reduce(lambda d, k: d.setdefault(k, {}), keys[:-1], data)[keys[-1]] = value
+
+
+def _get_key_values_to_move(
+    d: Dict[str, Any],
+    parent_key: str = "",
+    keys_to_move: List[tuple[str, str]] | None = None,
+) -> List[tuple[str, str]] | None:
+    if keys_to_move is None:
+        keys_to_move = []
+
+    if isinstance(d, dict):
+        for key, value in d.items():
+            if key == "value":
+                keys_to_move.append((parent_key, value))
+            elif isinstance(value, dict):
+                _get_key_values_to_move(
+                    value, parent_key + "." + key if parent_key else key, keys_to_move
+                )
+
+    return keys_to_move
+
+
+def _update_config_dict_with_value_keys(
+    keys_values_to_move: List[tuple[str, str]], data: dict[str, str]
+):
+    for parent, value in keys_values_to_move:
+        parents, parent = parent.rsplit(".", maxsplit=1)
+        value_to_set = {parent + ".value": value}
+        _update_nested_dict(key=parents, value=value_to_set, data=data)
+
+
+def _handle_key_dot_value_config_items(data_dict: dict) -> dict:
+    """Handle config parameters that are written as 'key.value'.
+
+    This function checks if there are any keys in the dictionary that are named value
+    and sets those key values a level higher in the nested dictionary. For instance,
+    the following dictionary:
+    {"input":
+        "vertical": {
+            "ksathorfrac": {
+                "value": 100
+                }
+            }
+        }
+    will become:
+    {"input":
+        "vertical": {
+            "ksathorfrac.value": 100
+            }
+        }
+
+
+    """
+    keys_values_to_move = _get_key_values_to_move(data_dict)
+    _update_config_dict_with_value_keys(
+        keys_values_to_move=keys_values_to_move, data=data_dict
+    )
+    return data_dict
+
+
 def get_config(
     *args,
-    config: Dict = {},
-    fallback=None,
-    root: Path = None,
+    config: Dict[str, Any] = {},
+    fallback: Any | None = None,
+    root: Path | None = None,
     abs_path: bool = False,
 ):
     """
     Get a config value at key(s).
-
-    Copy of hydromt.Model.get_config method to parse config outside of Model functions.
 
     See Also
     --------

--- a/hydromt_wflow/wflow.py
+++ b/hydromt_wflow/wflow.py
@@ -29,6 +29,7 @@ from shapely.geometry import box
 from hydromt_wflow.utils import (
     DATADIR,
     convert_to_wflow_v1_sbm,
+    get_config,
     mask_raster_from_layer,
     read_csv_results,
 )
@@ -4877,7 +4878,7 @@ Run setup_soilmaps first"
         This function should be followed by write_config() to write the upgraded file.
         """
         config_out = convert_to_wflow_v1_sbm(self.config, logger=self.logger)
-        self._config = dict()
+        self._config = tomlkit.TOMLDocument()
         for option in config_out:
             self.set_config(option, config_out[option])
 
@@ -6107,10 +6108,10 @@ change name input.path_forcing "
         >> get_config('b.c') # # identical to get_config('b','c')
         >> {'d': 2}
         """
-        item = super().get_config(*args, abs_path=abs_path)
-        if isinstance(item, tomlkit.items.Item):
-            return item.unwrap()
-        elif item is None:
-            return fallback
-        else:
-            return item
+        return get_config(
+            *args,
+            config=self.config,
+            fallback=fallback,
+            abs_path=abs_path,
+            root=self.root,
+        )

--- a/hydromt_wflow/wflow.py
+++ b/hydromt_wflow/wflow.py
@@ -5735,15 +5735,26 @@ change name input.path_forcing "
             self._config.append(tomlkit.key(keys), value)
             return
 
-        current = self._config[keys[0]]
+        if len(keys) == 1:
+            self._config.update({keys[0]: value})
+            return
 
-        for idx in range(1, len(keys)):
-            if keys[idx] not in current:
+        current = self._config
+        for idx in range(0, len(keys)):
+            if idx != len(keys) - 1:
                 remaining_key = tomlkit.key(keys[idx:])
-                current.update({remaining_key: value})
+            else:
+                remaining_key = keys[idx]
+            if keys[idx] not in current or not isinstance(current[keys[idx]], dict):
                 break
             else:
                 current = current[keys[idx]]
+
+        if remaining_key in current:
+            _ = current.pop(remaining_key)
+
+        current.append(remaining_key, value)
+        # current.update({remaining_key: value})
 
     def _update_naming(self, rename_dict: dict):
         """Update the naming of the model variables.

--- a/hydromt_wflow/wflow.py
+++ b/hydromt_wflow/wflow.py
@@ -5730,9 +5730,15 @@ change name input.path_forcing "
         else:
             keys = args
 
-        reduce(lambda d, k: d.setdefault(k, {}), keys[:-1], self._config)[keys[-1]] = (
-            value
-        )
+        reduce(lambda d, k: d.setdefault(k, {}), keys[:-1], self._config)
+
+        # the double walk is necessary because of a bug in tomlkit
+        # (see https://github.com/python-poetry/tomlkit/issues/410)
+        branch = self._config
+        for key in keys[:-1]:
+            branch = branch[key]
+
+        branch[keys[-1]] = value
 
     def _update_naming(self, rename_dict: dict):
         """Update the naming of the model variables.

--- a/hydromt_wflow/wflow.py
+++ b/hydromt_wflow/wflow.py
@@ -6076,7 +6076,7 @@ change name input.path_forcing "
             fallback value if key(s) not found in config, by default None.
         abs_path: bool, optional
             If True return the absolute path relative to the model root,
-            by deafult False.
+            by default False.
             NOTE: this assumes the config is located in model root!
 
         Returns

--- a/hydromt_wflow/wflow.py
+++ b/hydromt_wflow/wflow.py
@@ -5740,30 +5740,37 @@ change name input.path_forcing "
             for key, inner_value in value.items():
                 self.set_config(*keys, key, inner_value)
 
+        # if the first key is not present
+        # we can just set the entire thing straight
         if keys[0] not in self._config:
             self._config.append(tomlkit.key(keys), value)
             return
 
+        # If there is only one key we also just set that directly as
+        # a string key instead of the dotted variant
         if len(keys) == 1:
             self._config.update({keys[0]: value})
             return
 
         current = self._config
-        for idx in range(0, len(keys)):
+        for idx in range(len(keys)):
             if idx != len(keys) - 1:
                 remaining_key = tomlkit.key(keys[idx:])
             else:
                 remaining_key = keys[idx]
+
             if keys[idx] not in current or not isinstance(current[keys[idx]], dict):
                 break
-            else:
-                current = current[keys[idx]]
 
+            current = current[keys[idx]]
+
+        # tomlkit's update function doesn't work properly
+        # so instead of updating we take the key out if it is in there
+        # and readd it afterwards
         if remaining_key in current:
             _ = current.pop(remaining_key)
 
         current[remaining_key] = value
-        # current.update({remaining_key: value})
 
     def _update_naming(self, rename_dict: dict):
         """Update the naming of the model variables.

--- a/hydromt_wflow/wflow.py
+++ b/hydromt_wflow/wflow.py
@@ -5785,7 +5785,7 @@ change name input.path_forcing "
         # key bookkeeping, resulting in invalid toml, so instead
         # if we see a mapping, we go over it recursively
         # and manually add all of its keys, because of cloning issues.
-        if isinstance(value, (dict, tomlkit.items.Table)):
+        if isinstance(value, (dict, tomlkit.items.AbstractTable)):
             for key, inner_value in value.items():
                 self.set_config(*keys, key, inner_value)
 

--- a/hydromt_wflow/wflow.py
+++ b/hydromt_wflow/wflow.py
@@ -5723,12 +5723,12 @@ change name input.path_forcing "
         self._initialize_config()
         if len(args) < 2:
             raise TypeError("set_config() requires a least one key and one value.")
+        if not all([isinstance(part, str) for part in args[:-1]]):
+            raise TypeError("All but last argument for set_config must be str")
+
         args = list(args)
         value = args.pop(-1)
-        if isinstance(args[0], str):
-            keys = args[0].split(".")
-        else:
-            keys = args
+        keys = reduce(lambda acc, arg: [*acc, *arg.split(".")], args, [])
 
         reduce(lambda d, k: d.setdefault(k, {}), keys[:-1], self._config)
 

--- a/hydromt_wflow/wflow.py
+++ b/hydromt_wflow/wflow.py
@@ -5753,7 +5753,7 @@ change name input.path_forcing "
         if remaining_key in current:
             _ = current.pop(remaining_key)
 
-        current.append(remaining_key, value)
+        current[remaining_key] = value
         # current.update({remaining_key: value})
 
     def _update_naming(self, rename_dict: dict):

--- a/hydromt_wflow/wflow.py
+++ b/hydromt_wflow/wflow.py
@@ -4877,6 +4877,7 @@ Run setup_soilmaps first"
         The other components stay the same.
         This function should be followed by write_config() to write the upgraded file.
         """
+        self.read()
         config_out = convert_to_wflow_v1_sbm(self.config, logger=self.logger)
         self._config = tomlkit.TOMLDocument()
         for option in config_out:

--- a/hydromt_wflow/wflow.py
+++ b/hydromt_wflow/wflow.py
@@ -5730,15 +5730,34 @@ change name input.path_forcing "
         value = args.pop(-1)
         keys = reduce(lambda acc, arg: [*acc, *arg.split(".")], args, [])
 
-        reduce(lambda d, k: d.setdefault(k, {}), keys[:-1], self._config)
+        if keys[0] not in self._config:
+            self._config.append(tomlkit.key(keys), value)
+            return
+
+        current = self._config[keys[0]]
+
+        for idx in range(1, len(keys)):
+            if not current.is_super_table():
+                remaining_key = tomlkit.key(keys[idx:])
+                current.update({remaining_key: value})
+                break
+            else:
+                current = current[keys[idx]]
 
         # the double walk is necessary because of a bug in tomlkit
         # (see https://github.com/python-poetry/tomlkit/issues/410)
-        branch = self._config
-        for key in keys[:-1]:
-            branch = branch[key]
+        # branch = self._config
+        # for key in keys[:-1]:
+        #     branch = branch[key]
 
-        branch[keys[-1]] = value
+        # branch[keys[-1]] = value
+
+        # if keys[-1] == "value":
+        #     branch._is_super_table = False
+
+        # grouped = _handle_key_dot_value_config_items(self._config)
+
+        # self._config = grouped
 
     def _update_naming(self, rename_dict: dict):
         """Update the naming of the model variables.

--- a/hydromt_wflow/wflow.py
+++ b/hydromt_wflow/wflow.py
@@ -5703,24 +5703,73 @@ change name input.path_forcing "
 
     def set_config(self, *args):
         """
-        Update the config dictionary at key(s) with values.
+        Update the config toml at key(s) with values.
+
+        This function is made to maintain the structure of your toml file.
+        When adding keys it will look for the most specific header present in
+        the toml file and add it under that.
+
+        meaning that if you have a config toml that is empty and you run
+        ``wflow_model.set_config("input.forcing.scale", 1)``
+
+        it will result in the following file:
+
+        .. code-block:: toml
+
+            input.forcing.scale = 1
+
+
+        however if your toml file looks like this before:
+
+        .. code-block:: toml
+
+            [input.forcing]
+
+        (i.e. you have a header in there that has no keys)
+
+        then after the insertion it will look like this:
+
+        .. code-block:: toml
+
+            [input.forcing]
+            scale = 1
+
+
+        .. warning::
+
+            Due to limitations of the underlying library it is currently not possible to
+            create new headers (i.e. groups like ``input.forcing`` in the example above)
+            programmatically, and they will need to be added to the default config
+            toml document
+
+
+        .. warning::
+
+            Even though the underlying config object behaves like a dictionary, it is
+            not, it is a ``tomlkit.TOMLDocument``. Due to implementation limitations,
+            error scan easily be introduced if this structure is modified by hand.
+            Therefore we strongly discourage users from manually modying it, and
+            instead ask them to use this ``set_config`` function to avoid problems.
 
         Parameters
         ----------
-        args : str, tuple
-            if tuple, minimal length of two
+        args : str, tuple, list
+            if tuple or list, minimal length of two
             keys can given by multiple args: ('key1', 'key2', 'value')
             or a string with '.' indicating a new level: ('key1.key2', 'value')
 
         Examples
         --------
-        >> # self.config = {'a': 1, 'b': {'c': {'d': 2}}}
+        .. code-block:: ipython
 
-        >> set_config('a', 99)
-        >> {'a': 99, 'b': {'c': {'d': 2}}}
+            >> self.config
+            >> {'a': 1, 'b': {'c': {'d': 2}}}
 
-        >> set_config('b', 'c', 'd', 99) # identical to set_config('b.d.e', 99)
-        >> {'a': 1, 'b': {'c': {'d': 99}}}
+            >> self.set_config('a', 99)
+            >> {'a': 99, 'b': {'c': {'d': 2}}}
+
+            >> self.set_config('b', 'c', 'd', 99) # identical to set_config('b.d.e', 99)
+            >> {'a': 1, 'b': {'c': {'d': 99}}}
         """
         self._initialize_config()
         if len(args) < 2:

--- a/hydromt_wflow/wflow.py
+++ b/hydromt_wflow/wflow.py
@@ -5781,10 +5781,10 @@ change name input.path_forcing "
         value = args.pop(-1)
         keys = reduce(lambda acc, arg: [*acc, *arg.split(".")], args, [])
 
-        # if we try to set dictionaries as values directly tomlkit will messup the
+        # if we try to set dictionaries as values directly tomlkit will mess up the
         # key bookkeeping, resulting in invalid toml, so instead
         # if we see a mapping, we go over it recursively
-        # and manually add all of it's keys, which does work for some reason
+        # and manually add all of its keys, because of cloning issues.
         if isinstance(value, (dict, tomlkit.items.Table)):
             for key, inner_value in value.items():
                 self.set_config(*keys, key, inner_value)

--- a/hydromt_wflow/wflow.py
+++ b/hydromt_wflow/wflow.py
@@ -5737,27 +5737,12 @@ change name input.path_forcing "
         current = self._config[keys[0]]
 
         for idx in range(1, len(keys)):
-            if not current.is_super_table():
+            if keys[idx] not in current:
                 remaining_key = tomlkit.key(keys[idx:])
                 current.update({remaining_key: value})
                 break
             else:
                 current = current[keys[idx]]
-
-        # the double walk is necessary because of a bug in tomlkit
-        # (see https://github.com/python-poetry/tomlkit/issues/410)
-        # branch = self._config
-        # for key in keys[:-1]:
-        #     branch = branch[key]
-
-        # branch[keys[-1]] = value
-
-        # if keys[-1] == "value":
-        #     branch._is_super_table = False
-
-        # grouped = _handle_key_dot_value_config_items(self._config)
-
-        # self._config = grouped
 
     def _update_naming(self, rename_dict: dict):
         """Update the naming of the model variables.

--- a/hydromt_wflow/wflow.py
+++ b/hydromt_wflow/wflow.py
@@ -6,7 +6,6 @@ import codecs
 import glob
 import logging
 import os
-from functools import reduce
 from os.path import basename, dirname, isdir, isfile, join
 from pathlib import Path
 from typing import Any, Dict, List
@@ -5779,7 +5778,7 @@ change name input.path_forcing "
 
         args = list(args)
         value = args.pop(-1)
-        keys = reduce(lambda acc, arg: [*acc, *arg.split(".")], args, [])
+        keys = [part for arg in args for part in arg.split(".")]
 
         # if we try to set dictionaries as values directly tomlkit will mess up the
         # key bookkeeping, resulting in invalid toml, so instead

--- a/hydromt_wflow/wflow_sediment.py
+++ b/hydromt_wflow/wflow_sediment.py
@@ -935,6 +935,7 @@ river cells."
         This function should be followed by ``write_config`` to write the upgraded TOML
         file and by ``write_grid`` to write the upgraded static netcdf input file.
         """
+        self.read()
         config_out = convert_to_wflow_v1_sediment(self.config, logger=self.logger)
         self._config = TOMLDocument()
         for option in config_out:

--- a/hydromt_wflow/wflow_sediment.py
+++ b/hydromt_wflow/wflow_sediment.py
@@ -8,6 +8,7 @@ import geopandas as gpd
 import numpy as np
 import pandas as pd
 import xarray as xr
+from tomlkit import TOMLDocument
 
 from hydromt_wflow.utils import (
     DATADIR,
@@ -935,7 +936,7 @@ river cells."
         file and by ``write_grid`` to write the upgraded static netcdf input file.
         """
         config_out = convert_to_wflow_v1_sediment(self.config, logger=self.logger)
-        self._config = dict()
+        self._config = TOMLDocument()
         for option in config_out:
             self.set_config(option, config_out[option])
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -386,9 +386,9 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6a/9e/2064975477fdc887e47ad42157e214526dcad8f317a948dee17e1659a62f/terminado-0.18.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e6/34/ebdc18bae6aa14fbee1a08b63c015c72b64868ff7dae68808ab500c492e2/tinycss2-1.4.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f9/b6/a447b5e4ec71e13871be01ba81f5dfc9d0af7e473da256ff46bc0e24026f/tomlkit-0.13.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/03/98/eb27cc78ad3af8e302c9d8ff4977f5026676e130d28dd7578132a457170c/toolz-1.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/22/55/b78a464de78051a30599ceb6983b01d8f732e6f69bf37b4ed07f642ac0fc/tornado-6.4.2-cp38-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl
@@ -719,9 +719,9 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6a/9e/2064975477fdc887e47ad42157e214526dcad8f317a948dee17e1659a62f/terminado-0.18.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e6/34/ebdc18bae6aa14fbee1a08b63c015c72b64868ff7dae68808ab500c492e2/tinycss2-1.4.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f9/b6/a447b5e4ec71e13871be01ba81f5dfc9d0af7e473da256ff46bc0e24026f/tomlkit-0.13.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/03/98/eb27cc78ad3af8e302c9d8ff4977f5026676e130d28dd7578132a457170c/toolz-1.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/61/cc/58b1adeb1bb46228442081e746fcdbc4540905c87e8add7c277540934edb/tornado-6.4.2-cp38-abi3-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl
@@ -1116,9 +1116,9 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6a/9e/2064975477fdc887e47ad42157e214526dcad8f317a948dee17e1659a62f/terminado-0.18.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e6/34/ebdc18bae6aa14fbee1a08b63c015c72b64868ff7dae68808ab500c492e2/tinycss2-1.4.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5c/51/51c3f2884d7bab89af25f678447ea7d297b53b5a3b5730a7cb2ef6069f07/tomli-2.2.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f9/b6/a447b5e4ec71e13871be01ba81f5dfc9d0af7e473da256ff46bc0e24026f/tomlkit-0.13.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/03/98/eb27cc78ad3af8e302c9d8ff4977f5026676e130d28dd7578132a457170c/toolz-1.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/22/55/b78a464de78051a30599ceb6983b01d8f732e6f69bf37b4ed07f642ac0fc/tornado-6.4.2-cp38-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl
@@ -1434,9 +1434,9 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6a/9e/2064975477fdc887e47ad42157e214526dcad8f317a948dee17e1659a62f/terminado-0.18.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e6/34/ebdc18bae6aa14fbee1a08b63c015c72b64868ff7dae68808ab500c492e2/tinycss2-1.4.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/32/b0963458706accd9afcfeb867c0f9175a741bf7b19cd424230714d722198/tomli-2.2.1-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f9/b6/a447b5e4ec71e13871be01ba81f5dfc9d0af7e473da256ff46bc0e24026f/tomlkit-0.13.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/03/98/eb27cc78ad3af8e302c9d8ff4977f5026676e130d28dd7578132a457170c/toolz-1.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/61/cc/58b1adeb1bb46228442081e746fcdbc4540905c87e8add7c277540934edb/tornado-6.4.2-cp38-abi3-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl
@@ -1740,9 +1740,9 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/2a/2f/63d2cacc0e525f8e3398bcf32bd3620385f22cd1600834ec49d7f3597a7b/rioxarray-0.19.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/34/49/738e07d10bbc67cae0dcfe5a484c6e518a517f4f90550dda2adf3a78b9f2/shapely-2.1.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5c/51/51c3f2884d7bab89af25f678447ea7d297b53b5a3b5730a7cb2ef6069f07/tomli-2.2.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f9/b6/a447b5e4ec71e13871be01ba81f5dfc9d0af7e473da256ff46bc0e24026f/tomlkit-0.13.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/03/98/eb27cc78ad3af8e302c9d8ff4977f5026676e130d28dd7578132a457170c/toolz-1.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8b/54/b1ae86c0973cc6f0210b53d508ca3641fb6d0c56823f288d108bc7ab3cc8/typing_extensions-4.13.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/31/08/aa4fdfb71f7de5176385bd9e90852eaf6b5d622735020ad600f2bab54385/typing_inspection-0.4.0-py3-none-any.whl
@@ -1959,9 +1959,9 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/2a/2f/63d2cacc0e525f8e3398bcf32bd3620385f22cd1600834ec49d7f3597a7b/rioxarray-0.19.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e3/f0/9f8cdf2258d7aed742459cea51c70d184de92f5d2d6f5f7f1ded90a18c31/shapely-2.1.0-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/32/b0963458706accd9afcfeb867c0f9175a741bf7b19cd424230714d722198/tomli-2.2.1-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f9/b6/a447b5e4ec71e13871be01ba81f5dfc9d0af7e473da256ff46bc0e24026f/tomlkit-0.13.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/03/98/eb27cc78ad3af8e302c9d8ff4977f5026676e130d28dd7578132a457170c/toolz-1.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8b/54/b1ae86c0973cc6f0210b53d508ca3641fb6d0c56823f288d108bc7ab3cc8/typing_extensions-4.13.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/31/08/aa4fdfb71f7de5176385bd9e90852eaf6b5d622735020ad600f2bab54385/typing_inspection-0.4.0-py3-none-any.whl
@@ -2077,9 +2077,9 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/2a/2f/63d2cacc0e525f8e3398bcf32bd3620385f22cd1600834ec49d7f3597a7b/rioxarray-0.19.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/34/49/738e07d10bbc67cae0dcfe5a484c6e518a517f4f90550dda2adf3a78b9f2/shapely-2.1.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5c/51/51c3f2884d7bab89af25f678447ea7d297b53b5a3b5730a7cb2ef6069f07/tomli-2.2.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f9/b6/a447b5e4ec71e13871be01ba81f5dfc9d0af7e473da256ff46bc0e24026f/tomlkit-0.13.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/03/98/eb27cc78ad3af8e302c9d8ff4977f5026676e130d28dd7578132a457170c/toolz-1.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8b/54/b1ae86c0973cc6f0210b53d508ca3641fb6d0c56823f288d108bc7ab3cc8/typing_extensions-4.13.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/31/08/aa4fdfb71f7de5176385bd9e90852eaf6b5d622735020ad600f2bab54385/typing_inspection-0.4.0-py3-none-any.whl
@@ -2175,9 +2175,9 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/2a/2f/63d2cacc0e525f8e3398bcf32bd3620385f22cd1600834ec49d7f3597a7b/rioxarray-0.19.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e3/f0/9f8cdf2258d7aed742459cea51c70d184de92f5d2d6f5f7f1ded90a18c31/shapely-2.1.0-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/32/b0963458706accd9afcfeb867c0f9175a741bf7b19cd424230714d722198/tomli-2.2.1-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f9/b6/a447b5e4ec71e13871be01ba81f5dfc9d0af7e473da256ff46bc0e24026f/tomlkit-0.13.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/03/98/eb27cc78ad3af8e302c9d8ff4977f5026676e130d28dd7578132a457170c/toolz-1.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8b/54/b1ae86c0973cc6f0210b53d508ca3641fb6d0c56823f288d108bc7ab3cc8/typing_extensions-4.13.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/31/08/aa4fdfb71f7de5176385bd9e90852eaf6b5d622735020ad600f2bab54385/typing_inspection-0.4.0-py3-none-any.whl
@@ -2479,9 +2479,9 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/2a/2f/63d2cacc0e525f8e3398bcf32bd3620385f22cd1600834ec49d7f3597a7b/rioxarray-0.19.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/16/6f/bcb800b2579b995bb61f429445b7328ae2336155964ca5f6c367ebd3fd17/shapely-2.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f9/b6/a447b5e4ec71e13871be01ba81f5dfc9d0af7e473da256ff46bc0e24026f/tomlkit-0.13.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/03/98/eb27cc78ad3af8e302c9d8ff4977f5026676e130d28dd7578132a457170c/toolz-1.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8b/54/b1ae86c0973cc6f0210b53d508ca3641fb6d0c56823f288d108bc7ab3cc8/typing_extensions-4.13.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/31/08/aa4fdfb71f7de5176385bd9e90852eaf6b5d622735020ad600f2bab54385/typing_inspection-0.4.0-py3-none-any.whl
@@ -2707,9 +2707,9 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/2a/2f/63d2cacc0e525f8e3398bcf32bd3620385f22cd1600834ec49d7f3597a7b/rioxarray-0.19.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/0a/2002b39da6935f361da9c6437e45e01f0ebac81f66c08c01da974227036c/shapely-2.1.0-cp310-cp310-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f9/b6/a447b5e4ec71e13871be01ba81f5dfc9d0af7e473da256ff46bc0e24026f/tomlkit-0.13.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/03/98/eb27cc78ad3af8e302c9d8ff4977f5026676e130d28dd7578132a457170c/toolz-1.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8b/54/b1ae86c0973cc6f0210b53d508ca3641fb6d0c56823f288d108bc7ab3cc8/typing_extensions-4.13.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/31/08/aa4fdfb71f7de5176385bd9e90852eaf6b5d622735020ad600f2bab54385/typing_inspection-0.4.0-py3-none-any.whl
@@ -3012,9 +3012,9 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/2a/2f/63d2cacc0e525f8e3398bcf32bd3620385f22cd1600834ec49d7f3597a7b/rioxarray-0.19.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/92/07/3e2738c542d73182066196b8ce99388cb537d19e300e428d50b1537e3b21/shapely-2.1.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/6b/c54ede5dc70d648cc6361eaf429304b02f2871a345bbdd51e993d6cdf550/tomli-2.2.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f9/b6/a447b5e4ec71e13871be01ba81f5dfc9d0af7e473da256ff46bc0e24026f/tomlkit-0.13.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/03/98/eb27cc78ad3af8e302c9d8ff4977f5026676e130d28dd7578132a457170c/toolz-1.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8b/54/b1ae86c0973cc6f0210b53d508ca3641fb6d0c56823f288d108bc7ab3cc8/typing_extensions-4.13.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/31/08/aa4fdfb71f7de5176385bd9e90852eaf6b5d622735020ad600f2bab54385/typing_inspection-0.4.0-py3-none-any.whl
@@ -3239,9 +3239,9 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/2a/2f/63d2cacc0e525f8e3398bcf32bd3620385f22cd1600834ec49d7f3597a7b/rioxarray-0.19.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fd/28/7bb5b1944d4002d4b2f967762018500381c3b532f98e456bbda40c3ded68/shapely-2.1.0-cp311-cp311-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6a/1c/4a2dcde4a51b81be3530565e92eda625d94dafb46dbeb15069df4caffc34/tomli-2.2.1-cp311-cp311-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f9/b6/a447b5e4ec71e13871be01ba81f5dfc9d0af7e473da256ff46bc0e24026f/tomlkit-0.13.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/03/98/eb27cc78ad3af8e302c9d8ff4977f5026676e130d28dd7578132a457170c/toolz-1.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8b/54/b1ae86c0973cc6f0210b53d508ca3641fb6d0c56823f288d108bc7ab3cc8/typing_extensions-4.13.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/31/08/aa4fdfb71f7de5176385bd9e90852eaf6b5d622735020ad600f2bab54385/typing_inspection-0.4.0-py3-none-any.whl
@@ -3365,9 +3365,9 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/2a/2f/63d2cacc0e525f8e3398bcf32bd3620385f22cd1600834ec49d7f3597a7b/rioxarray-0.19.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/16/6f/bcb800b2579b995bb61f429445b7328ae2336155964ca5f6c367ebd3fd17/shapely-2.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f9/b6/a447b5e4ec71e13871be01ba81f5dfc9d0af7e473da256ff46bc0e24026f/tomlkit-0.13.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/03/98/eb27cc78ad3af8e302c9d8ff4977f5026676e130d28dd7578132a457170c/toolz-1.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8b/54/b1ae86c0973cc6f0210b53d508ca3641fb6d0c56823f288d108bc7ab3cc8/typing_extensions-4.13.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/31/08/aa4fdfb71f7de5176385bd9e90852eaf6b5d622735020ad600f2bab54385/typing_inspection-0.4.0-py3-none-any.whl
@@ -3472,9 +3472,9 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/2a/2f/63d2cacc0e525f8e3398bcf32bd3620385f22cd1600834ec49d7f3597a7b/rioxarray-0.19.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/0a/2002b39da6935f361da9c6437e45e01f0ebac81f66c08c01da974227036c/shapely-2.1.0-cp310-cp310-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f9/b6/a447b5e4ec71e13871be01ba81f5dfc9d0af7e473da256ff46bc0e24026f/tomlkit-0.13.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/03/98/eb27cc78ad3af8e302c9d8ff4977f5026676e130d28dd7578132a457170c/toolz-1.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8b/54/b1ae86c0973cc6f0210b53d508ca3641fb6d0c56823f288d108bc7ab3cc8/typing_extensions-4.13.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/31/08/aa4fdfb71f7de5176385bd9e90852eaf6b5d622735020ad600f2bab54385/typing_inspection-0.4.0-py3-none-any.whl
@@ -3595,9 +3595,9 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/2a/2f/63d2cacc0e525f8e3398bcf32bd3620385f22cd1600834ec49d7f3597a7b/rioxarray-0.19.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/92/07/3e2738c542d73182066196b8ce99388cb537d19e300e428d50b1537e3b21/shapely-2.1.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/6b/c54ede5dc70d648cc6361eaf429304b02f2871a345bbdd51e993d6cdf550/tomli-2.2.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f9/b6/a447b5e4ec71e13871be01ba81f5dfc9d0af7e473da256ff46bc0e24026f/tomlkit-0.13.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/03/98/eb27cc78ad3af8e302c9d8ff4977f5026676e130d28dd7578132a457170c/toolz-1.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8b/54/b1ae86c0973cc6f0210b53d508ca3641fb6d0c56823f288d108bc7ab3cc8/typing_extensions-4.13.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/31/08/aa4fdfb71f7de5176385bd9e90852eaf6b5d622735020ad600f2bab54385/typing_inspection-0.4.0-py3-none-any.whl
@@ -3701,9 +3701,9 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/2a/2f/63d2cacc0e525f8e3398bcf32bd3620385f22cd1600834ec49d7f3597a7b/rioxarray-0.19.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fd/28/7bb5b1944d4002d4b2f967762018500381c3b532f98e456bbda40c3ded68/shapely-2.1.0-cp311-cp311-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6a/1c/4a2dcde4a51b81be3530565e92eda625d94dafb46dbeb15069df4caffc34/tomli-2.2.1-cp311-cp311-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f9/b6/a447b5e4ec71e13871be01ba81f5dfc9d0af7e473da256ff46bc0e24026f/tomlkit-0.13.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/03/98/eb27cc78ad3af8e302c9d8ff4977f5026676e130d28dd7578132a457170c/toolz-1.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8b/54/b1ae86c0973cc6f0210b53d508ca3641fb6d0c56823f288d108bc7ab3cc8/typing_extensions-4.13.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/31/08/aa4fdfb71f7de5176385bd9e90852eaf6b5d622735020ad600f2bab54385/typing_inspection-0.4.0-py3-none-any.whl
@@ -6641,7 +6641,7 @@ packages:
 - pypi: .
   name: hydromt-wflow
   version: 0.8.1.dev0
-  sha256: 6995cbcb0dca71222786e547dfcd8da8dcd98ba830bf1295e426413d5d7f39cf
+  sha256: d20eecf31d0d90afeb48f54144515f253082c38cbb819ce61307bc4afa632392
   requires_dist:
   - dask
   - geopandas>=0.10
@@ -6652,7 +6652,7 @@ packages:
   - pyproj
   - scipy
   - shapely
-  - toml
+  - tomlkit
   - xarray
   - pre-commit ; extra == 'dev'
   - ruff ; extra == 'dev'
@@ -13762,11 +13762,6 @@ packages:
   purls: []
   size: 3503410
   timestamp: 1699202577803
-- pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
-  name: toml
-  version: 0.10.2
-  sha256: 806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b
-  requires_python: '>=2.6,!=3.0.*,!=3.1.*,!=3.2.*'
 - pypi: https://files.pythonhosted.org/packages/5c/51/51c3f2884d7bab89af25f678447ea7d297b53b5a3b5730a7cb2ef6069f07/tomli-2.2.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   name: tomli
   version: 2.2.1
@@ -13797,6 +13792,11 @@ packages:
   version: 1.2.0
   sha256: 188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/f9/b6/a447b5e4ec71e13871be01ba81f5dfc9d0af7e473da256ff46bc0e24026f/tomlkit-0.13.2-py3-none-any.whl
+  name: tomlkit
+  version: 0.13.2
+  sha256: 7a974427f6e119197f670fbbbeae7bef749a6c14e793db934baefc1b5f03efde
+  requires_python: '>=3.8'
 - pypi: https://files.pythonhosted.org/packages/03/98/eb27cc78ad3af8e302c9d8ff4977f5026676e130d28dd7578132a457170c/toolz-1.0.0-py3-none-any.whl
   name: toolz
   version: 1.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
   "pyproj",
   "scipy",
   "shapely",
-  "toml",
+  "tomlkit",
   "xarray",
 ]
 

--- a/tests/data/grouped_model_config.toml
+++ b/tests/data/grouped_model_config.toml
@@ -1,0 +1,53 @@
+dir_output = "run_default"
+
+[time]
+calendar     = "proleptic_gregorian"
+starttime    = "2010-02-01T00:00:00"
+endtime      = "2010-02-10T00:00:00"
+time_units   = "days since 1900-01-01 00:00:00"
+timestepsecs = 86400
+
+[logging]
+loglevel = "info"
+
+[model]
+type                         = "sbm"
+gravitational_snow_transport = true
+snow                         = true
+reinit                       = true
+reservoirs                   = false
+lakes                        = false
+glacier                      = false
+kin_wave_iteration           = true
+kw_river_tstep               = 900
+kw_land_tstep                = 3600
+
+[state]
+path_input  = "instate/instates.nc"
+path_output = "outstate/outstates.nc"
+
+[input]
+path_forcing = "inmaps.nc"
+path_static  = "staticmaps.nc"
+
+[state.variables]
+vegetation_canopy_water__depth                     = "canopystorage"
+soil_water_sat-zone__depth                         = "satwaterdepth"
+soil_layer_water_unsat-zone__depth                 = "ustorelayerdepth"
+soil_surface__temperature                          = "tsoil"
+"snowpack~dry__leq-depth"                          = "snow"
+"snowpack~liquid__depth"                           = "snowwater"
+land_surface_water__instantaneous_volume_flow_rate = "q_land"
+land_surface_water__instantaneous_depth            = "h_land"
+subsurface_water__volume_flow_rate                 = "ssf"
+river_water__instantaneous_volume_flow_rate        = "q_river"
+river_water__instantaneous_depth                   = "h_river"
+
+[input.vertical]
+khorfrac.value = 100
+kverfrac.value = 200
+
+[input.static]
+"soil~compacted_surface_water__infiltration_capacity".value = 5
+soil_water_sat-zone_bottom__max_leakage_volume_flux.value   = 0
+"soil_root~wet__sigmoid_function_shape_parameter".value     = -500

--- a/tests/data/grouped_model_config.toml
+++ b/tests/data/grouped_model_config.toml
@@ -1,26 +1,26 @@
 dir_output = "run_default"
 
 [time]
-calendar     = "proleptic_gregorian"
-starttime    = "2010-02-01T00:00:00"
-endtime      = "2010-02-10T00:00:00"
-time_units   = "days since 1900-01-01 00:00:00"
+calendar = "proleptic_gregorian"
+starttime = "2010-02-01T00:00:00"
+endtime = "2010-02-10T00:00:00"
+time_units = "days since 1900-01-01 00:00:00"
 timestepsecs = 86400
 
 [logging]
 loglevel = "info"
 
 [model]
-type                         = "sbm"
+type = "sbm"
 gravitational_snow_transport = true
-snow                         = true
-reinit                       = true
-reservoirs                   = false
-lakes                        = false
-glacier                      = false
-kin_wave_iteration           = true
-kw_river_tstep               = 900
-kw_land_tstep                = 3600
+snow = true
+reinit = true
+reservoirs = false
+lakes = false
+glacier = false
+kin_wave_iteration = true
+kw_river_tstep = 900
+kw_land_tstep = 3600
 
 [state]
 path_input  = "instate/instates.nc"
@@ -31,23 +31,27 @@ path_forcing = "inmaps.nc"
 path_static  = "staticmaps.nc"
 
 [input.static]
-"soil~compacted_surface_water__infiltration_capacity".value = 5
-soil_water_sat-zone_bottom__max_leakage_volume_flux.value   = 0
-"soil_root~wet__sigmoid_function_shape_parameter".value     = -500
+"staticsoil~compacted_surface_water__infiltration_capacity".value = 5
+"soil_root~wet__sigmoid_function_shape_parameter".value = -500
+soil_water_sat-zone_bottom__max_leakage_volume_flux.value = 0
 
 [input.forcing]
 netcdf.name = "blah.nc"
-scale       = 100
+scale = 1
+
+[input.vertical]
+khorfrac.value = 100
+kverfract.value = 200
 
 [state.variables]
-vegetation_canopy_water__depth                     = "canopystorage"
-soil_water_sat-zone__depth                         = "satwaterdepth"
-soil_layer_water_unsat-zone__depth                 = "ustorelayerdepth"
-soil_surface__temperature                          = "tsoil"
-"snowpack~dry__leq-depth"                          = "snow"
-"snowpack~liquid__depth"                           = "snowwater"
+vegetation_canopy_water__depth = "canopystorage"
+soil_water_sat-zone__depth = "satwaterdepth"
+soil_layer_water_unsat-zone__depth = "ustorelayerdepth"
+soil_surface__temperature = "tsoil"
+"snowpack~dry__leq-depth" = "snow"
+"snowpack~liquid__depth" = "snowwater"
 land_surface_water__instantaneous_volume_flow_rate = "q_land"
-land_surface_water__instantaneous_depth            = "h_land"
-subsurface_water__volume_flow_rate                 = "ssf"
-river_water__instantaneous_volume_flow_rate        = "q_river"
-river_water__instantaneous_depth                   = "h_river"
+land_surface_water__instantaneous_depth = "h_land"
+subsurface_water__volume_flow_rate = "ssf"
+river_water__instantaneous_volume_flow_rate = "q_river"
+river_water__instantaneous_depth = "h_river"

--- a/tests/data/grouped_model_config.toml
+++ b/tests/data/grouped_model_config.toml
@@ -1,26 +1,26 @@
 dir_output = "run_default"
 
 [time]
-calendar = "proleptic_gregorian"
-starttime = "2010-02-01T00:00:00"
-endtime = "2010-02-10T00:00:00"
-time_units = "days since 1900-01-01 00:00:00"
+calendar     = "proleptic_gregorian"
+starttime    = "2010-02-01T00:00:00"
+endtime      = "2010-02-10T00:00:00"
+time_units   = "days since 1900-01-01 00:00:00"
 timestepsecs = 86400
 
 [logging]
 loglevel = "info"
 
 [model]
-type = "sbm"
+type                         = "sbm"
 gravitational_snow_transport = true
-snow = true
-reinit = true
-reservoirs = false
-lakes = false
-glacier = false
-kin_wave_iteration = true
-kw_river_tstep = 900
-kw_land_tstep = 3600
+snow                         = true
+reinit                       = true
+reservoirs                   = false
+lakes                        = false
+glacier                      = false
+kin_wave_iteration           = true
+kw_river_tstep               = 900
+kw_land_tstep                = 3600
 
 [state]
 path_input  = "instate/instates.nc"
@@ -32,26 +32,22 @@ path_static  = "staticmaps.nc"
 
 [input.static]
 "staticsoil~compacted_surface_water__infiltration_capacity".value = 5
-"soil_root~wet__sigmoid_function_shape_parameter".value = -500
-soil_water_sat-zone_bottom__max_leakage_volume_flux.value = 0
+"soil_root~wet__sigmoid_function_shape_parameter".value           = -500
+soil_water_sat-zone_bottom__max_leakage_volume_flux.value         = 0
 
 [input.forcing]
 netcdf.name = "blah.nc"
-scale = 1
-
-[input.vertical]
-khorfrac.value = 100
-kverfract.value = 200
+scale       = 1
 
 [state.variables]
-vegetation_canopy_water__depth = "canopystorage"
-soil_water_sat-zone__depth = "satwaterdepth"
-soil_layer_water_unsat-zone__depth = "ustorelayerdepth"
-soil_surface__temperature = "tsoil"
-"snowpack~dry__leq-depth" = "snow"
-"snowpack~liquid__depth" = "snowwater"
+vegetation_canopy_water__depth                     = "canopystorage"
+soil_water_sat-zone__depth                         = "satwaterdepth"
+soil_layer_water_unsat-zone__depth                 = "ustorelayerdepth"
+soil_surface__temperature                          = "tsoil"
+"snowpack~dry__leq-depth"                          = "snow"
+"snowpack~liquid__depth"                           = "snowwater"
 land_surface_water__instantaneous_volume_flow_rate = "q_land"
-land_surface_water__instantaneous_depth = "h_land"
-subsurface_water__volume_flow_rate = "ssf"
-river_water__instantaneous_volume_flow_rate = "q_river"
-river_water__instantaneous_depth = "h_river"
+land_surface_water__instantaneous_depth            = "h_land"
+subsurface_water__volume_flow_rate                 = "ssf"
+river_water__instantaneous_volume_flow_rate        = "q_river"
+river_water__instantaneous_depth                   = "h_river"

--- a/tests/data/grouped_model_config.toml
+++ b/tests/data/grouped_model_config.toml
@@ -30,6 +30,15 @@ path_output = "outstate/outstates.nc"
 path_forcing = "inmaps.nc"
 path_static  = "staticmaps.nc"
 
+[input.static]
+"soil~compacted_surface_water__infiltration_capacity".value = 5
+soil_water_sat-zone_bottom__max_leakage_volume_flux.value   = 0
+"soil_root~wet__sigmoid_function_shape_parameter".value     = -500
+
+[input.forcing]
+netcdf.name = "blah.nc"
+scale       = 100
+
 [state.variables]
 vegetation_canopy_water__depth                     = "canopystorage"
 soil_water_sat-zone__depth                         = "satwaterdepth"
@@ -42,12 +51,3 @@ land_surface_water__instantaneous_depth            = "h_land"
 subsurface_water__volume_flow_rate                 = "ssf"
 river_water__instantaneous_volume_flow_rate        = "q_river"
 river_water__instantaneous_depth                   = "h_river"
-
-[input.vertical]
-khorfrac.value = 100
-kverfrac.value = 200
-
-[input.static]
-"soil~compacted_surface_water__infiltration_capacity".value = 5
-soil_water_sat-zone_bottom__max_leakage_volume_flux.value   = 0
-"soil_root~wet__sigmoid_function_shape_parameter".value     = -500

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,7 @@ from os.path import abspath, dirname, join
 from pathlib import Path
 
 import numpy as np
-from tomlkit import dump, load
+from tomlkit import load
 
 from hydromt_wflow import WflowModel, WflowSedimentModel
 from hydromt_wflow.utils import get_grid_from_config
@@ -148,12 +148,6 @@ def test_config_toml_grouping(tmpdir):
 
     with open(TESTDATADIR / "grouped_model_config.toml") as file:
         expected_config = load(file)
-
-    with open("expected.toml", "w") as file:
-        dump(expected_config, file)
-
-    with open("actual.toml", "w") as file:
-        dump(written_config, file)
 
     assert written_config == expected_config
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,6 @@ from os.path import abspath, dirname, join
 from pathlib import Path
 
 import numpy as np
-from tomlkit import load
 
 from hydromt_wflow import WflowModel, WflowSedimentModel
 from hydromt_wflow.utils import get_grid_from_config
@@ -107,56 +106,15 @@ def test_convert_to_wflow_v1_sediment():
     assert "a_kodatie" in wflow.grid
 
 
-def test_config_toml_grouping(tmpdir):
+def test_config_toml_overwrite(tmpdir):
     dummy_model = WflowModel(root=tmpdir, mode="w")
     dummy_model.read_config()
     dummy_model.set_config(
         "input.vertical.khorfrac.value",
         100,
     )
-
     dummy_model.set_config(
-        "input",
-        "vertical.kverfract",
-        "value",
+        "input.vertical.khorfrac.value",
         200,
     )
-    dummy_model.set_config(
-        "input",
-        "forcing",
-        "netcdf.name",
-        "blah.nc",
-    )
-    dummy_model.set_config(
-        "input",
-        "forcing",
-        "scale",
-        1,
-    )
-    dummy_model.set_config(
-        "input",
-        "static",
-        "staticsoil~compacted_surface_water__infiltration_capacity",
-        "value",
-        5,
-    )
-    dummy_model.set_config(
-        "input",
-        "static",
-        "soil_root~wet__sigmoid_function_shape_parameter",
-        "value",
-        -500,
-    )
-    dummy_model.set_config(
-        "input.static.soil_water_sat-zone_bottom__max_leakage_volume_flux.value", 0
-    )
-
-    dummy_model.write()
-
-    with open(tmpdir / "wflow_sbm.toml", "r") as file:
-        written_config = load(file)
-
-    with open(TESTDATADIR / "grouped_model_config.toml") as file:
-        expected_config = load(file)
-
-    assert written_config == expected_config
+    assert dummy_model.get_config("input.vertical.khorfrac.value") == 200

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,7 @@ from os.path import abspath, dirname, join
 from pathlib import Path
 
 import numpy as np
-from tomlkit import dump, load
+from tomlkit import load
 
 from hydromt_wflow import WflowModel, WflowSedimentModel
 from hydromt_wflow.utils import get_grid_from_config
@@ -153,17 +153,10 @@ def test_config_toml_grouping(tmpdir):
 
     dummy_model.write()
 
-    from shutil import copyfile
-
-    copyfile(Path(dummy_model.root) / "wflow_sbm.toml", "written.toml")
-
     with open(tmpdir / "wflow_sbm.toml", "r") as file:
         written_config = load(file)
 
     with open(TESTDATADIR / "grouped_model_config.toml") as file:
         expected_config = load(file)
-
-    with open("actual.toml", "w") as file:
-        dump(written_config, file)
 
     assert written_config == expected_config

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -67,7 +67,7 @@ def test_grid_from_config(demda):
 
 
 def test_convert_to_wflow_v1_sbm():
-    # Initiliaze wflow model
+    # Initialize wflow model
     root = join(TESTDATADIR, "wflow_v0x", "sbm")
     config_fn = "wflow_sbm_v0x.toml"
 
@@ -83,7 +83,7 @@ def test_convert_to_wflow_v1_sbm():
 
 
 def test_convert_to_wflow_v1_sediment():
-    # Initiliaze wflow model
+    # Initialize wflow model
     root = join(EXAMPLEDIR, "wflow_upgrade", "sediment")
     config_fn = "wflow_sediment_v0x.toml"
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,7 @@ from os.path import abspath, dirname, join
 from pathlib import Path
 
 import numpy as np
-from tomlkit import load
+from tomlkit import dump, load
 
 from hydromt_wflow import WflowModel, WflowSedimentModel
 from hydromt_wflow.utils import get_grid_from_config
@@ -109,6 +109,7 @@ def test_convert_to_wflow_v1_sediment():
 
 def test_config_toml_grouping(tmpdir):
     dummy_model = WflowModel(root=tmpdir, mode="w")
+    dummy_model.read_config()
     dummy_model.set_config(
         "input.vertical.khorfrac.value",
         100,
@@ -116,13 +117,25 @@ def test_config_toml_grouping(tmpdir):
 
     dummy_model.set_config(
         "input",
-        "vertical",
-        "kverfract",
+        "vertical.kverfract",
         "value",
         200,
     )
     dummy_model.set_config(
         "input",
+        "forcing",
+        "netcdf.name",
+        "blah.nc",
+    )
+    dummy_model.set_config(
+        "input",
+        "forcing",
+        "scale",
+        1,
+    )
+    dummy_model.set_config(
+        "input",
+        "static",
         "staticsoil~compacted_surface_water__infiltration_capacity",
         "value",
         5,
@@ -140,10 +153,17 @@ def test_config_toml_grouping(tmpdir):
 
     dummy_model.write()
 
+    from shutil import copyfile
+
+    copyfile(Path(dummy_model.root) / "wflow_sbm.toml", "written.toml")
+
     with open(tmpdir / "wflow_sbm.toml", "r") as file:
         written_config = load(file)
 
     with open(TESTDATADIR / "grouped_model_config.toml") as file:
         expected_config = load(file)
+
+    with open("actual.toml", "w") as file:
+        dump(written_config, file)
 
     assert written_config == expected_config

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,7 @@ from os.path import abspath, dirname, join
 from pathlib import Path
 
 import numpy as np
-from tomlkit import load
+from tomlkit import dump, load
 
 from hydromt_wflow import WflowModel, WflowSedimentModel
 from hydromt_wflow.utils import get_grid_from_config
@@ -149,6 +149,12 @@ def test_config_toml_grouping(tmpdir):
     with open(TESTDATADIR / "grouped_model_config.toml") as file:
         expected_config = load(file)
 
+    with open("expected.toml", "w") as file:
+        dump(expected_config, file)
+
+    with open("actual.toml", "w") as file:
+        dump(written_config, file)
+
     assert written_config == expected_config
 
 
@@ -156,11 +162,11 @@ def test_config_toml_overwrite(tmpdir):
     dummy_model = WflowModel(root=tmpdir, mode="w")
     dummy_model.read_config()
     dummy_model.set_config(
-        "input.vertical.khorfrac.value",
+        "input.forcing.khorfrac.value",
         100,
     )
     dummy_model.set_config(
-        "input.vertical.khorfrac.value",
+        "input.forcing.khorfrac.value",
         200,
     )
-    assert dummy_model.get_config("input.vertical.khorfrac.value") == 200
+    assert dummy_model.get_config("input.forcing.khorfrac.value") == 200

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,6 +4,7 @@ from os.path import abspath, dirname, join
 from pathlib import Path
 
 import numpy as np
+from tomlkit import load
 
 from hydromt_wflow import WflowModel, WflowSedimentModel
 from hydromt_wflow.utils import get_grid_from_config
@@ -104,6 +105,51 @@ def test_convert_to_wflow_v1_sediment():
     assert "fsagg_soil" in wflow.grid
     assert "c_govers" in wflow.grid
     assert "a_kodatie" in wflow.grid
+
+
+def test_config_toml_grouping(tmpdir):
+    dummy_model = WflowModel(root=tmpdir, mode="w")
+    dummy_model.read_config()
+
+    dummy_model.set_config(
+        "input",
+        "forcing",
+        "netcdf.name",
+        "blah.nc",
+    )
+    dummy_model.set_config(
+        "input",
+        "forcing",
+        "scale",
+        1,
+    )
+    dummy_model.set_config(
+        "input",
+        "static",
+        "staticsoil~compacted_surface_water__infiltration_capacity",
+        "value",
+        5,
+    )
+    dummy_model.set_config(
+        "input",
+        "static",
+        "soil_root~wet__sigmoid_function_shape_parameter",
+        "value",
+        -500,
+    )
+    dummy_model.set_config(
+        "input.static.soil_water_sat-zone_bottom__max_leakage_volume_flux.value", 0
+    )
+
+    dummy_model.write()
+
+    with open(tmpdir / "wflow_sbm.toml", "r") as file:
+        written_config = load(file)
+
+    with open(TESTDATADIR / "grouped_model_config.toml") as file:
+        expected_config = load(file)
+
+    assert written_config == expected_config
 
 
 def test_config_toml_overwrite(tmpdir):


### PR DESCRIPTION
## Issue addressed
Fixes #232 

## Explanation
It turns out that `tomlkit` is quite a buggy implementation so this ended up taking quite long but we got there in the end. The rule we ended up with in the end is that when a value is set, it will be added to the most specific existing table in the config, if this does not exist it will be added to the root. This does mean that if for example the config file should have an input block like so:

```toml
[input.static]
foo = "bar"
mew = "bark"
```

then the table should be added to the toml document before hand even if there are no keys for it yet like so:

```toml
[input.static]
```

Then subsequent sets will be added to this table 
## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
