### PR TITLE
Update on standard names wflow v1.x

### DIFF
--- a/hydromt_wflow/naming.py
+++ b/hydromt_wflow/naming.py
@@ -305,7 +305,7 @@ WFLOW_NAMES = {
     },
     "nonpaddy_irrigation_areas": {
         "wflow_v0": "vertical.nonpaddy.irrigation_areas",
-        "wflow_v1": "land~irrigated-non-paddy_area__number",
+        "wflow_v1": "land~irrigated-non-paddy_area__count",
     },
     "nonpaddy_irrigation_trigger": {
         "wflow_v0": "vertical.nonpaddy.irrigation_trigger",

--- a/hydromt_wflow/wflow.py
+++ b/hydromt_wflow/wflow.py
@@ -4459,7 +4459,7 @@ Run setup_soilmaps first"
         lulcmap_name: str = "wflow_landuse",
         output_names: Dict = {
             "land~irrigated-paddy_area__number": "paddy_irrigation_areas",
-            "land~irrigated-non-paddy_area__number": "nonpaddy_irrigation_areas",
+            "land~irrigated-non-paddy_area__count": "nonpaddy_irrigation_areas",
             "land~irrigated-paddy__irrigation_trigger_flag": "paddy_irrigation_trigger",
             "land~irrigated-non-paddy__irrigation_trigger_flag": "nonpaddy_irrigation_trigger",  # noqa: E501
         },
@@ -4637,7 +4637,7 @@ Run setup_soilmaps first"
         lai_threshold: float = 0.2,
         output_names: Dict = {
             "land~irrigated-paddy_area__number": "paddy_irrigation_areas",
-            "land~irrigated-non-paddy_area__number": "nonpaddy_irrigation_areas",
+            "land~irrigated-non-paddy_area__count": "nonpaddy_irrigation_areas",
             "land~irrigated-paddy__irrigation_trigger_flag": "paddy_irrigation_trigger",
             "land~irrigated-non-paddy__irrigation_trigger_flag": "nonpaddy_irrigation_trigger",  # noqa: E501
         },


### PR DESCRIPTION
## Issue addressed
Fixes #401

## Explanation

### Completely New
- [ ] in naming.py add a new variable for `erosion_answers_rain_factor`: wflow v1 var is `soil_erosion__answers_rainfall_factor`, did not exist in v0 and no hydromt name needed.

### Renaming
- [ ] `river_bottom-and-bank_sediment__d50_diameter` by `river_bottom-and-bank_sediment__median_diameter` (updated v1 name)
- [ ]  `land_surface_sediment__d50_diameter` by `land_surface_sediment__median_diameter` (updated v1 name)
- [ ] `clay__d50_diameter` by `clay__mean_diameter` (updated v1 name)
- [ ] `silt__d50_diameter` by `silt__mean_diameter` (updated v1 name)
- [ ]  `sand__d50_diameter` by `sand__mean_diameter` (updated v1 name)
- [ ] `sediment_aggregates~small__d50_diameter` by `sediment_aggregates~small__mean_diameter` (updated v1 name)
- [ ] `sediment_aggregates~large__d50_diameter` by `sediment_aggregates~large__mean_diameter` (updated v1 name)
- [ ] `gravel__d50_diameter` by `gravel__mean_diameter` (updated v1 name)
- [ ] `land_surface_sediment__particle_density` and `river_sediment__particle_density` have been merged into one unique variable `sediment__particle_density`
- [ ] `fews_run` --> `fews_run__flag` (v0 to v1 name)
- [ ] `land~irrigated-non-paddy_area__number` --> `land~irrigated-non-paddy_area__count` (updated v1 name)
- [ ] `land~irrigated-paddy_area__number` --> `land~irrigated-paddy_area__count` (updated v1 name)
- [ ] `land_water_allocation_area__number` --> `land_water_allocation_area__count` (updated v1 name)
- [ ] `subcatchment_location__count` --> `subbasin_location__count` (updated v1 name, v0 name was `subcatchment`)
- [ ] `local_drain_direction` --> `basin__local_drain_direction` (updated v1 name)
- [ ] `pits` --> `basin_pit_location__mask` (v0 to v1 name)
- [ ] `land_drain_location__flag` --> `land_drain_location__mask` (updated v1 name)
- [ ] `reservoir_sediment~bedload__trapping_efficiency_coefficient` --> `reservoir_water_sediment~bedload__trapping_efficiency` (wflow_sediment) (updated v1 name)

### Demand flags (`[model.water_demand]`):
- [ ] `domestic` --> `domestic__flag` (v0 to v1 name)
- [ ] `industry` --> `industry__flag` (v0 to v1 name)
- [ ] `livestock` --> `livestock__flag` (v0 to v1 name)
- [ ] `paddy` --> `paddy__flag` (v0 to v1 name)
- [ ] `nonpaddy` --> `nonpaddy__flag` (v0 to v1 name)

### Model flags (`[model]`)
- [ ] `reinit` --> `cold_start__flag`  (v0 to v1 name)
- [ ] `sizeinmetres` --> `cell_length_in_meter__flag`  (v0 to v1 name)
- [ ] `reservoirs` --> `reservoir__flag` (v0 to v1 name)
- [ ] `lakes` --> `lake__flag` (v0 to v1 name)
- [ ] `snow` --> `snow__flag` (v0 to v1 name)
- [ ] `glacier` --> `glacier__flag` (v0 to v1 name)
- [ ] `pits` --> `pit__flag` (v0 to v1 name)
- [ ] `gravitational_snow_transport` --> `snow_gravitional_transport__flag`
- [ ] `thicknesslayers` --> `soil_layer__thickness`  (v0 to v1 name)
- [ ] `min_streamorder_land` --> `land_streamorder__min_count` (v0 to v1 name)
- [ ] `min_streamorder_river` --> `river_streamorder__min_count` (v0 to v1 name)
- [ ] `drains` --> `drain__flag`  (v0 to v1 name)
- [ ] `constanthead` --> `constanthead__flag`  (v0 to v1 name)
- [ ] `kin_wave_iteration` --> `kinematic_wave__adaptive_time_step_flag` (v0 to v1 name)
- [ ] `kw_land_tstep` --> `land_kinematic_wave__time_step` (v0 to v1 name)
- [ ] `kw_river_tstep` --> `river_kinematic_wave__time_step` (v0 to v1 name)
- [ ] `inertial_flow_alpha` --> `river_local_inertial_flow__alpha_coefficient` and `land_local_inertial_flow__alpha_coefficient` (note was previously one setting that controlled both, is now split into two, also holds for the 2 next options) (v0 to v1 name)
- [ ] `h_thresh` --> `river_water_flow_threshold__depth` and `land_surface_water_flow_threshold__depth` (v0 to v1 name)
- [ ] `froude_limit` --> `river_water_flow__froude_limit_flag` and `land_surface_water_flow__froude_limit_flag` (v0 to v1 name)
- [ ] `floodplain_1d` --> `floodplain_1d__flag` (v0 to v1 name)
- [ ] `inertial_flow_theta` --> `land_local_inertial_flow__theta_coefficient` (v0 to v1 name)
- [ ] `run_river_model` --> `run_river_model__flag` (wflow_sediment) (updated v1 name, v0 name was `runrivermodel`)
- [ ] `soilinfreduction` --> `soil_infiltration_reduction__flag` (v0 to v1 name)
- [ ] `transfermethod` --> `topog_sbm_transfer__flag` (v0 to v1 name)

## Checklist
- [ ] Updated tests or added new tests
- [ ] Branch is up to date with `main`
- [ ] Tests & pre-commit hooks pass
- [ ] Updated documentation if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
