### PR TITLE
update staticmaps_to_mapstack example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,8 @@ examples/wflow_test_sediment
 examples/wflow_test_extend_sediment
 examples/hydro_data
 examples/updated_staticmaps
+examples/wflow_piave_subbasin/staticmaps_updated.nc
+examples/wflow_piave_subbasin/wflow_sbm_updated.toml
 examples/data/wflow_upgrade/sbm/hydromt.log
 examples/data/wflow_upgrade/sbm/wflow_sbm_v1.toml
 examples/data/wflow_upgrade/sediment/hydromt.log

--- a/examples/convert_staticmaps_to_mapstack.ipynb
+++ b/examples/convert_staticmaps_to_mapstack.ipynb
@@ -31,10 +31,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import xarray as xr\n",
     "import shutil\n",
     "from os.path import join, exists\n",
-    "from os import listdir, rename\n",
+    "from os import listdir\n",
     "import hydromt\n",
     "from hydromt_wflow import WflowModel"
    ]
@@ -63,8 +62,8 @@
    "outputs": [],
    "source": [
     "root = \"wflow_piave_subbasin\"\n",
-    "mod = WflowModel(root, mode=\"r\")\n",
-    "ds = mod.grid  # here the staticmaps netcdf is loaded\n",
+    "wflow = WflowModel(root, mode=\"r\")\n",
+    "ds = wflow.grid  # here the staticmaps netcdf is loaded\n",
     "print(ds)"
    ]
   },
@@ -81,7 +80,7 @@
    "id": "8",
    "metadata": {},
    "source": [
-    "The raster module provides many raster GIS methods throught the **raster** Dataset accessor. To write a Dataset to a mapstack one line with code is sufficient. We only need to provide the output folder in which all raster files are saved. The default output format is *GeoTIFF*, but this can be changed with the `driver` argument. To write to PCRaster map-files it is recommended to have PCRaster python installed."
+    "The raster module provides many raster GIS methods through the **raster** Dataset accessor. To write a Dataset into several raster files (eg one geotiff file per map), one line with code is sufficient using [raster.to_mapstack](https://deltares.github.io/hydromt/stable/_generated/hydromt.gis.Dataset.raster.to_mapstack.html). We only need to provide the output folder in which all raster files are saved. The default output format is *GeoTIFF*, but this can be changed with the `driver` argument. To write to PCRaster map-files, pcraster python library should be installed."
    ]
   },
   {
@@ -91,11 +90,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Name of the folder where the tif files will be saved\n",
     "updated_staticmaps = \"updated_staticmaps\"\n",
+    "\n",
+    "# First remove the folder if it already exists\n",
     "if exists(updated_staticmaps):\n",
     "    shutil.rmtree(updated_staticmaps)\n",
     "\n",
+    "# Save the tif files\n",
     "ds.raster.to_mapstack(updated_staticmaps)\n",
+    "# Print the content of the folder\n",
     "listdir(updated_staticmaps)"
    ]
   },
@@ -104,7 +108,7 @@
    "id": "10",
    "metadata": {},
    "source": [
-    "Now the model files can easily be inspected and modified e.g. QGIS.\n",
+    "Now the model files can easily be inspected and modified for example using QGIS (e.g. with the Serval plugin).\n",
     "\n",
     "> **Note:** in QGIS, you can also visualize netcdf files but direct modification is not (yet) possible."
    ]
@@ -114,116 +118,75 @@
    "id": "11",
    "metadata": {},
    "source": [
-    "### Create staticmaps netcdf files based on mapstack"
+    "### Update a specific map using `setup_grid_from_raster`\n",
+    "\n",
+    "Lets say you have updated (manually or not) and the `KsatVer.tif` static map and that you would like to include it in your model. For demonstration purpose, we will make a copy and name it `KsatVer_updated.tif`."
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "id": "12",
    "metadata": {},
+   "outputs": [],
    "source": [
-    "If you want to update the staticmaps after modification the maps can be read into a Dataset by hydromt. We recommend the following workflow:\n",
-    "\n",
-    "* read the original model\n",
-    "* read the updated mapstack\n",
-    "* change the model root to write the updated model to a new directory\n",
-    "* update the staticmaps of the model\n",
-    "* write the model\n",
-    "\n",
-    "> **Note:** We do not read the forcing as it is faster to just copy the file instead of loading it into python and writing it back to netcdf.\n",
-    "\n",
-    "> **Note:** The staticgeoms might be changed because of manual changes in the wflow_river, lakes, reservoir or glacier staticmaps and are therefore not read here. To change these maps we recommend using the hydromt update method to keep the staticgeoms and maps aligned."
+    "old_map = join(updated_staticmaps, \"KsatVer.tif\")\n",
+    "updated_map = join(updated_staticmaps, \"KsatVer_updated.tif\")\n",
+    "shutil.copyfile(old_map, updated_map)"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "id": "13",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "# Read the model without the updated staticmaps\n",
-    "root = \"wflow_piave_subbasin\"\n",
-    "mod = WflowModel(root, mode=\"r\")\n",
-    "mod.read_grid()\n",
-    "mod.read_config()"
+    "You will need to find the `wflow variable` that corresponds to the map you updated, which in the case of `KsatVer.tif` is `soil_surface_water__vertical_saturated_hydraulic_conductivity`. For information on the available wflow variables, see the [Wflow documentation](https://deltares.github.io/Wflow.jl/dev/model_docs/parameters_intro.html)\n",
+    "\n",
+    "And then you can simply use [setup_grid_from_raster](https://deltares.github.io/hydromt_wflow/stable/_generated/hydromt_wflow.WflowModel.setup_grid_from_raster.html).\n",
+    "\n",
+    "In the below example, we will use python to update our model. If you wish to update via command line, the steps are:\n",
+    "\n",
+    "1. Create a data catalog entry for the maps in the \"updated_staticmaps\" folder\n",
+    "2. Prepare a hydromt config file with the steps: `setup_grid_from_raster`, `write_grid` and `write_config`\n",
+    "3. Call the `hydromt update` command line re-using the catalog and configuration file you created."
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "id": "14",
    "metadata": {},
-   "source": [
-    "### Adding updated maps\n",
-    "\n",
-    "Given some GeoTiff files, there are 2 ways to add their contents to your model: with or without renaming of the files.\n",
-    "\n",
-    "The simplest is to overwrite the entire grid by reading all `.tif` files produced using the steps above.\n",
-    "\n",
-    "> **Note:** If any maps have been manually updated (using QGIS), **do not rename the updated files**. WflowModel uses the filenames to generate variable names automatically. Renaming files can result in a WflowModel with staticmaps containing both the old and new versions of a map, which may lead to inconsistencies in the model."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "15",
-   "metadata": {},
    "outputs": [],
    "source": [
-    "# read the entire updated mapstack\n",
-    "ds_updated = hydromt.open_mfraster(join(updated_staticmaps, \"*.tif\"))\n",
-    "\n",
-    "# Reinitialize and update the new model staticmaps\n",
-    "mod._grid = xr.Dataset()\n",
-    "mod.set_grid(ds_updated)\n",
-    "\n",
-    "# Change root to not overwrite the original model\n",
-    "updated_root = \"wflow_piave_subbasin_updated\"\n",
-    "mod.set_root(updated_root)\n",
-    "mod.write()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "16",
-   "metadata": {},
-   "source": [
-    "### Update static maps separately using `setup_grid_from_raster`\n",
-    "\n",
-    "Lets say you have updated and renamed the `KsatVer.tif` static map to `KsatVer_updated.tif`, and that you would like to include it in your model.\n",
-    "\n",
-    "You will need to find the `wflow variable` that corresponds to the map you updated, which in the case of `KsatVer.tif` is `soil_surface_water__vertical_saturated_hydraulic_conductivity`. For information on the available wflow variables, see the [Wflow documentation](https://deltares.github.io/Wflow.jl/dev/user_guide/toml_file.html)\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "17",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "mod = WflowModel(root, mode=\"r\")\n",
-    "mod.read_grid()\n",
-    "mod.read_config()\n",
+    "# Instantiate a new WflowModel object in read/write mode (r+) to be able to update it\n",
+    "wflow = WflowModel(root, mode=\"r+\")\n",
     "\n",
     "# `KsatVer` corresponds to the `soil_surface_water__vertical_saturated_hydraulic_conductivity` variable\n",
     "wflow_variable = \"soil_surface_water__vertical_saturated_hydraulic_conductivity\"\n",
-    "print(f\"Before setup_grid_from_raster: {mod._config['input']['static'][wflow_variable]}\")\n",
+    "print(f\"Before setup_grid_from_raster: {wflow._config['input']['static'][wflow_variable]}\")\n",
     "\n",
-    "# For this example we just copy and rename `KsatVer.tif`, but in practice this would be a different file\n",
-    "old_map = join(updated_staticmaps, \"KsatVer.tif\")\n",
+    "# Path to the (updated) `KsatVer_updated.tif`\n",
     "updated_map = join(updated_staticmaps, \"KsatVer_updated.tif\")\n",
-    "shutil.copyfile(old_map, updated_map)\n",
     "\n",
-    "mod.setup_grid_from_raster(raster_fn=updated_map, reproject_method='nearest', wflow_variables=[wflow_variable])\n",
-    "print(f\"After setup_grid_from_raster: {mod._config['input']['static'][wflow_variable]}\")"
+    "# Update the model KsatVer map with setup_grid_from_raster\n",
+    "wflow.setup_grid_from_raster(\n",
+    "    raster_fn=updated_map, \n",
+    "    reproject_method='nearest',\n",
+    "    variables=[\"KsatVer_updated\"], \n",
+    "    wflow_variables=[wflow_variable],\n",
+    "    \n",
+    ")\n",
+    "print(f\"After setup_grid_from_raster: {wflow._config['input']['static'][wflow_variable]}\")\n",
+    "\n",
+    "# Write the updated grid and config files to new files\n",
+    "wflow.write_grid(fn_out=\"staticmaps_updated.nc\")\n",
+    "wflow.write_config(config_name=\"wflow_sbm_updated.toml\")\n"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "default",
+   "display_name": "hydromt_wflow",
    "language": "python",
    "name": "python3"
   },
@@ -237,7 +200,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.17"
+   "version": "3.11.12"
   }
  },
  "nbformat": 4,

--- a/examples/convert_staticmaps_to_mapstack.ipynb
+++ b/examples/convert_staticmaps_to_mapstack.ipynb
@@ -186,7 +186,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "hydromt_wflow",
+   "display_name": "default",
    "language": "python",
    "name": "python3"
   },
@@ -200,7 +200,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.12"
+   "version": "3.10.17"
   }
  },
  "nbformat": 4,

--- a/examples/convert_staticmaps_to_mapstack.ipynb
+++ b/examples/convert_staticmaps_to_mapstack.ipynb
@@ -80,7 +80,7 @@
    "id": "8",
    "metadata": {},
    "source": [
-    "The raster module provides many raster GIS methods through the **raster** Dataset accessor. To write a Dataset into several raster files (eg one geotiff file per map), one line with code is sufficient using [raster.to_mapstack](https://deltares.github.io/hydromt/stable/_generated/hydromt.gis.Dataset.raster.to_mapstack.html). We only need to provide the output folder in which all raster files are saved. The default output format is *GeoTIFF*, but this can be changed with the `driver` argument. To write to PCRaster map-files, pcraster python library should be installed."
+    "The raster module provides many raster GIS methods through the **raster** Dataset accessor. To write a Dataset into several raster files (eg one geotiff file per map), one line with code is sufficient using [raster.to_mapstack](https://deltares.github.io/hydromt/stable/_generated/hydromt.gis.Dataset.raster.to_mapstack.html). We only need to provide the output folder in which all raster files are saved. The default output format is *GeoTIFF*, but this can be changed with the `driver` argument."
    ]
   },
   {
@@ -120,7 +120,7 @@
    "source": [
     "### Update a specific map using `setup_grid_from_raster`\n",
     "\n",
-    "Lets say you have updated (manually or not) and the `KsatVer.tif` static map and that you would like to include it in your model. For demonstration purpose, we will make a copy and name it `KsatVer_updated.tif`."
+    "Let's say you have updated (manually or not) the `KsatVer.tif` static map and that you would like to include it in your model. For demonstration purpose, we will make a copy and name it `KsatVer_updated.tif`."
    ]
   },
   {
@@ -140,7 +140,7 @@
    "id": "13",
    "metadata": {},
    "source": [
-    "You will need to find the `wflow variable` that corresponds to the map you updated, which in the case of `KsatVer.tif` is `soil_surface_water__vertical_saturated_hydraulic_conductivity`. For information on the available wflow variables, see the [Wflow documentation](https://deltares.github.io/Wflow.jl/dev/model_docs/parameters_intro.html)\n",
+    "You will need to find the `wflow variable` that corresponds to the map you updated, which in the case of `KsatVer.tif` is `soil_surface_water__vertical_saturated_hydraulic_conductivity`. For information on the available wflow variables, see the [Wflow documentation](https://deltares.github.io/Wflow.jl/stable/model_docs/parameters_intro.html)\n",
     "\n",
     "And then you can simply use [setup_grid_from_raster](https://deltares.github.io/hydromt_wflow/stable/_generated/hydromt_wflow.WflowModel.setup_grid_from_raster.html).\n",
     "\n",


### PR DESCRIPTION
## Issue addressed
Late review of updated notebook in PR #408 

## Explanation
Sorry if it was not clear in the issue but the part that fully updates the staticmaps based on all tif files is not something that works. It because some of the variable have a third dimension (layer or time) and when you merge, instead of getting a unique variable (eg c) you then get (c_1, c_2, c_3 etc) so Wflow does not run.

Else all good! I mainly added a final write at the end of the examples to avoid people saying that the changes do not work after running the notebook :) (it happened before for the 1D connection example notebook)

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed
