### PR TITLE
Small conversion fix

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -32,6 +32,7 @@ Changed
 
 Fixed
 -----
+- Error when not output header is present in the v0.x toml to be converted
 - Updated installation guide (#376)
 
 Deprecated

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -32,7 +32,6 @@ Changed
 
 Fixed
 -----
-- Error when not output header is present in the v0.x toml to be converted
 - Updated installation guide (#376)
 
 Deprecated

--- a/hydromt_wflow/utils.py
+++ b/hydromt_wflow/utils.py
@@ -612,6 +612,8 @@ def _convert_to_wflow_v1(
 
     # Output netcdf_scalar section
     if get_config("netcdf", config=config, fallback=None) is not None:
+        if "output" not in config_out:
+            config_out["output"] = {}
         config_out["output"]["netcdf_scalar"] = {
             "path": get_config(
                 "netcdf.path", config=config, fallback="output_scalar.nc"
@@ -630,6 +632,8 @@ def _convert_to_wflow_v1(
 
     # Output csv section
     if get_config("csv", config=config, fallback=None) is not None:
+        if "output" not in config_out:
+            config_out["output"] = {}
         config_out["output"]["csv"] = {}
 
         config_out["output"]["csv"]["path"] = get_config(


### PR DESCRIPTION
## Issue addressed
Fixes error on absence of output header

## Explanation
Simply add the dictionary for 'output' when none is present. This is done under the if statements of netcdf (scalar) and csv. No test has been written because it would require a separate file, which seems overkill. The reason for the necessity of a separate file stems from the fact that the model is read/ re-read in `upgrade_to_v1_wflow`, which means that any pop operation on the config file is nullified.

## Checklist
- [ ] Updated tests or added new tests
- [ ] Branch is up to date with `main`
- [ ] Tests & pre-commit hooks pass
- [ ] Updated documentation if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
