### PR TITLE
Some updates for the config migration

### DIFF
--- a/hydromt_wflow/components/config.py
+++ b/hydromt_wflow/components/config.py
@@ -2,7 +2,7 @@
 
 import logging
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, Dict, Tuple, cast
 
 import tomlkit
 from hydromt.model import Model
@@ -57,16 +57,6 @@ class WflowConfigComponent(ModelComponent):
         self._default_template_filename: Path | str | None = default_template_filename
 
         super().__init__(model=model)
-
-    def __eq__(self, other: ModelComponent):
-        """Compare components based on content."""
-        if not isinstance(other, WflowConfigComponent):
-            raise ValueError(
-                f"Can't compare {self.__class__.__name__} \
-with type {type(other).__name__}"
-            )
-        other_config = cast(WflowConfigComponent, other)
-        return self.data == other_config.data
 
     ## Private
     def _initialize(self, skip_read=False) -> None:
@@ -154,7 +144,7 @@ defaulting to {_new_path.as_posix()}"
             logger.warning("Model config has no data, skip writing.")
 
     ## Modifying methods
-    def get(
+    def get_value(
         self,
         *args,
         fallback: Any | None = None,
@@ -196,3 +186,29 @@ defaulting to {_new_path.as_posix()}"
         self._initialize()
         # Refer to utils function of set_config
         set_config(self._data, *args)
+
+    # Testing
+    def test_equal(self, other: ModelComponent) -> Tuple[bool, Dict[str, str]]:
+        """Compare components based on content.
+
+        Parameters
+        ----------
+        other : ModelComponent
+            The component to compare against.
+
+        Returns
+        -------
+        tuple[bool, Dict[str, str]]
+            True if the components are equal, and a dict with the associated errors per
+            property checked.
+        """
+        eq, errors = super().test_equal(other)
+        if not eq:
+            return eq, errors
+        other_config = cast(WflowConfigComponent, other)
+
+        # for once python does the recursion for us
+        if self.data == other_config.data:
+            return True, {}
+        else:
+            return False, {"config": "Configs are not equal"}

--- a/hydromt_wflow/wflow.py
+++ b/hydromt_wflow/wflow.py
@@ -5800,7 +5800,7 @@ change name input.path_forcing "
         >> get_config('b.c') # # identical to get_config('b','c')
         >> {'d': 2}
         """
-        return self.config.get(
+        return self.config.get_value(
             *args,
             fallback=fallback,
             abs_path=abs_path,

--- a/hydromt_wflow/wflow.py
+++ b/hydromt_wflow/wflow.py
@@ -129,6 +129,37 @@ class WflowModel(Model):
 
     # SETUP METHODS
     @hydromt_step
+    def setup_config(self, data: Dict[str, Any]):
+        """Set the config dictionary at key(s) with values.
+
+        Parameters
+        ----------
+        data: Dict[str,Any]
+            A dictionary with the values to be set. keys can be dotted like in
+            :py:meth:`~hydromt_wflow.components.config.WflowConfigComponent.set`
+
+        Examples
+        --------
+        Setting data as a nested dictionary::
+
+
+            >> self.setup_config({'a': 1, 'b': {'c': {'d': 2}}})
+            >> self.data
+            {'a': 1, 'b': {'c': {'d': 2}}}
+
+        Setting data using dotted notation::
+
+            >> self.setup_config({'a.d.f.g': 1, 'b': {'c': {'d': 2}}})
+            >> self.data
+            {'a': {'d':{'f':{'g': 1}}}, 'b': {'c': {'d': 2}}}
+
+        """
+        if len(data) > 0:
+            logger.debug("Setting model config options.")
+        for k, v in data.items():
+            self.config.set(k, v)
+
+    @hydromt_step
     def setup_basemaps(
         self,
         region: Dict,

--- a/tests/components/test_config_component.py
+++ b/tests/components/test_config_component.py
@@ -131,8 +131,24 @@ def test_wflow_config_component_read_default(
     assert component._data is None  # Assert no data or structure yet
 
     # Read at init
-    assert len(component.data) == 6
-    assert component.data["dir_output"] == "run_default"
+    assert len(component.data) == 0
+
+    # Reading the template only happens in w and w+ modes
+    # Set it to read mode
+    type(mock_model).root = PropertyMock(
+        side_effect=lambda: ModelRoot(tmp_path, mode="w"),
+    )
+
+    # Setup the component
+    component2 = WflowConfigComponent(
+        model=mock_model,
+        default_template_filename=Path(DATADIR, "wflow", "wflow_sbm.toml"),
+    )
+    assert component2._data is None  # Assert no data or structure yet
+
+    # Read at init
+    assert len(component2.data) == 6
+    assert component2.data["dir_output"] == "run_default"
     assert (
         f"No config file found at {Path(tmp_path, component._filename).as_posix()} \
 defaulting to"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -179,4 +179,4 @@ def test_config_toml_overwrite(tmpdir):
         "input.forcing.khorfrac.value",
         200,
     )
-    assert dummy_model.config.get("input.forcing.khorfrac.value") == 200
+    assert dummy_model.config.get_value("input.forcing.khorfrac.value") == 200


### PR DESCRIPTION
## Issue addressed
Fixes #451 

## Explanation
This PR contains some updates for the WflowConfigComponent:

- Add the template config when instantiating the config component in WflowModel
- Update the config.read method to only use the template in w and w+ mode
- Harmonise functions and names with the name in hydromt core ConfigComponent
- Add the `setup_config` method: in core model.setup_config was moved to ConfigComponent.update. I for now added setup_config in WflowModel to harmonise if all setup_methods do remain at the level of model. Bue it may change later. It's at least there for now when we re-enable testing.

## Checklist
- [ ] Updated tests or added new tests
- [ ] Branch is up to date with `main`
- [ ] Tests & pre-commit hooks pass
- [ ] Updated documentation if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
