### PR TITLE
Feat/remove config

### DIFF
--- a/hydromt_wflow/wflow.py
+++ b/hydromt_wflow/wflow.py
@@ -5884,13 +5884,13 @@ change name input.path_forcing "
             *args,
         )
 
-    def remove_config(self, *args: list[str]) -> Any:
+    def remove_config(self, *args: str) -> Any:
         """
         Remove a config key and return its value.
 
         Parameters
         ----------
-        key: str, tuple, list
+        key: str, tuple[str, ...]
             Key to remove from the config.
             Can be a dotted toml string when providing a list of strings.
 
@@ -5899,8 +5899,11 @@ change name input.path_forcing "
         The popped value, or raises a KeyError if the key is not found.
         """
         current = self.config
-        for i, key in enumerate(args):
-            if i == len(args) - 1:
+        for index, key in enumerate(args):
+            if current is None:
+                raise KeyError(f"Key {'.'.join(args)} not found in config.")
+
+            if index == len(args) - 1:
                 # Last key, pop it
                 current = current.pop(key)
                 break

--- a/tests/test_model_methods.py
+++ b/tests/test_model_methods.py
@@ -1426,3 +1426,6 @@ def test_remove_config(example_wflow_model):
 
     with pytest.raises(KeyError):
         example_wflow_model.remove_config("model", "river_routing")
+
+    with pytest.raises(KeyError):
+        example_wflow_model.remove_config("model", "non_existing_key", "some_stuff")


### PR DESCRIPTION
## Issue addressed
Fixes #463

## Explanation
Since we don't want users to directly interact with the `model.config` object as a dictionary, I have added a `remove_config` function to remove keys from the configuration.

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed
