### PR TITLE
fix: resolve warnings from tests

### DIFF
--- a/hydromt_wflow/wflow.py
+++ b/hydromt_wflow/wflow.py
@@ -2350,8 +2350,8 @@ Using default storage/outflow function parameters."
                 logger=self.logger,
             )
             # update/replace xout and yout in gdf_org from gdf_wateroutlet:
-            gdf_org["xout"] = gdf_wateroutlet["xout"]
-            gdf_org["yout"] = gdf_wateroutlet["yout"]
+            gdf_org.loc[:, "xout"] = gdf_wateroutlet["xout"].values
+            gdf_org.loc[:, "yout"] = gdf_wateroutlet["yout"].values
 
         else:
             self.logger.warning(
@@ -4811,7 +4811,7 @@ Run setup_soilmaps first"
             buffer=1000,
             predicate="intersects",
             handle_nodata=NoDataStrategy.IGNORE,
-        )
+        ).copy()  # Ensure we have a copy to resolve SettingWithCopyWarning
 
         # Check if the geodataframe is empty
         if irrigated_area is None or irrigated_area.empty:

--- a/hydromt_wflow/wflow.py
+++ b/hydromt_wflow/wflow.py
@@ -4002,7 +4002,10 @@ Run setup_soilmaps first"
             self.set_grid(ds_out["gauges"], name=f"gauges_{mapname}")
             # Derive the gauges staticgeoms
             gdf_tributary = ds_out["gauges"].raster.vectorize()
-            gdf_tributary["geometry"] = gdf_tributary["geometry"].centroid
+            centroid = utils.planar_operation_in_utm(
+                gdf_tributary["geometry"], lambda geom: geom.centroid
+            )
+            gdf_tributary["geometry"] = centroid
             gdf_tributary["value"] = gdf_tributary["value"].astype(
                 ds_out["gauges"].dtype
             )

--- a/hydromt_wflow/workflows/connect.py
+++ b/hydromt_wflow/workflows/connect.py
@@ -9,6 +9,8 @@ import pandas as pd
 import xarray as xr
 from shapely.geometry import LineString, MultiLineString, Point
 
+from hydromt_wflow.utils import planar_operation_in_utm
+
 logger = logging.getLogger(__name__)
 
 
@@ -266,7 +268,8 @@ def wflow_1dmodel_connection(
                 gdf_tributaries = gpd.GeoDataFrame()
         else:
             gdf_trib = gdf_trib.to_crs(ds_model.raster.crs)
-            gdf_trib["geometry"] = gdf_trib.centroid
+            centroid = planar_operation_in_utm(gdf_trib, lambda geom: geom.centroid)
+            gdf_trib["geometry"] = centroid
 
             # Merge with gdf_tributary if include_river_boundaries
             # else only keep intersecting tributaries

--- a/hydromt_wflow/workflows/connect.py
+++ b/hydromt_wflow/workflows/connect.py
@@ -265,6 +265,7 @@ def wflow_1dmodel_connection(
             if not include_river_boundaries:
                 gdf_tributaries = gpd.GeoDataFrame()
         else:
+            gdf_trib = gdf_trib.to_crs(ds_model.raster.crs)
             gdf_trib["geometry"] = gdf_trib.centroid
 
             # Merge with gdf_tributary if include_river_boundaries

--- a/hydromt_wflow/workflows/forcing.py
+++ b/hydromt_wflow/workflows/forcing.py
@@ -169,7 +169,7 @@ def spatial_interpolation(
     nb_stations = len(gdf_stations)
     if mask_name is not None:
         basins = ds_like[mask_name].raster.vectorize()
-        nb_inside = gdf_stations.within(basins.unary_union).sum()
+        nb_inside = gdf_stations.within(basins.union_all()).sum()
         logger.info(
             f"Found {nb_stations} stations in the forcing data, "
             f"of which {nb_inside} are located inside the basin."

--- a/hydromt_wflow/workflows/glaciers.py
+++ b/hydromt_wflow/workflows/glaciers.py
@@ -115,8 +115,12 @@ storage per grid cell"
                 3857
             ).area  # area calculation needs projected crs
             gfrac = garea_cell / np.sum(garea_cell)
-            gdf_grid.loc[idxs, "glacierfrac"] += garea_cell / gdf_grid.loc[idxs, "area"]
-            gdf_grid.loc[idxs, "glacierstore"] += gfrac * glacier["glacierstore"]
+            gdf_grid.loc[idxs, "glacierfrac"] += (
+                garea_cell / gdf_grid.loc[idxs, "area"]
+            ).astype(np.float32)
+            gdf_grid.loc[idxs, "glacierstore"] += (
+                gfrac * glacier["glacierstore"]
+            ).astype(np.float32)
 
     # reproject back to original projection
     # Create the rasterized glacier storage map

--- a/hydromt_wflow/workflows/landuse.py
+++ b/hydromt_wflow/workflows/landuse.py
@@ -10,7 +10,7 @@ import pandas as pd
 import xarray as xr
 from shapely.geometry import box
 
-from .demand import create_grid_from_bbox
+from hydromt_wflow.workflows.demand import create_grid_from_bbox
 
 logger = logging.getLogger(__name__)
 

--- a/hydromt_wflow/workflows/soilparams.py
+++ b/hydromt_wflow/workflows/soilparams.py
@@ -192,7 +192,9 @@ def get_ks_veg(ksat_vertical, sndppt, LAI, alfa=4.5, beta=5):
 
     """
     # get the saturated hydraulic conductivity with fully developed vegetation.
-    ksmax = 10 ** (3.5 - 1.5 * sndppt**0.13 + np.log10(ksat_vertical))
+    ksmax = 10 ** (
+        3.5 - 1.5 * sndppt**0.13 + np.log10(ksat_vertical.where(ksat_vertical > 0))
+    )
     # get the saturated hydraulic conductivity based on soil and
     # vegetation mean LAI
     ks = ksmax - (ksmax - ksat_vertical) / (1 + (LAI / alfa) ** beta)

--- a/hydromt_wflow/workflows/waterbodies.py
+++ b/hydromt_wflow/workflows/waterbodies.py
@@ -324,21 +324,21 @@ please use one of [gww, jrc] or None."
 
     # Get resarea either from EO or database depending
     if "Area_avg" in gdf.columns:
-        df_out["resarea"] = gdf["Area_avg"].values
+        df_out["resarea"] = gdf["Area_avg"].values.astype(np.float64)
         if timeseries_fn is not None:
             df_out.loc[pd.notna(df_EO["maxarea"]), "resarea"] = df_EO["maxarea"][
                 pd.notna(df_EO["maxarea"])
-            ].values
+            ].values.astype(np.float64)
         else:
             df_out.loc[pd.isna(df_out["resarea"]), "resarea"] = df_EO["maxarea"][
                 pd.isna(df_out["resarea"])
-            ].values
+            ].values.astype(np.float64)
     else:
-        df_out["resarea"] = df_EO["maxarea"].values
+        df_out["resarea"] = df_EO["maxarea"].values.astype(np.float64)
 
     # Get resmaxvolume from database
     if "Vol_avg" in gdf.columns:
-        df_out["resmaxvolume"] = gdf["Vol_avg"].values
+        df_out["resmaxvolume"] = gdf["Vol_avg"].values.astype(np.float64)
 
     # Compute target min and max fractions
     # First look if data is available from the database
@@ -353,7 +353,7 @@ please use one of [gww, jrc] or None."
     # (if a valid source is provided)
     # TODO for now assumes that the reservoir-db is used
     # (combination of GRanD and HydroLAKES)
-    gdf = gdf.fillna(value=np.nan)
+    gdf = gdf.fillna(value=np.nan).infer_objects(copy=False)
     for i in range(len(gdf["waterbody_id"])):
         # Initialise values
         dam_height = np.nanmax([gdf["Dam_height"].iloc[i], 0.0])
@@ -497,14 +497,15 @@ please use one of [gww, jrc] or None."
         df_out.resminfrac = df_EO["capmin"].values / df_out["resmaxvolume"].values
         df_out.resfullfrac = df_EO["capmax"].values / df_out["resmaxvolume"].values
     else:
-        df_out.loc[pd.isna(df_out["resminfrac"]), "resminfrac"] = (
-            df_EO.loc[pd.isna(df_out["resminfrac"]), "capmin"].values
-            / df_out.loc[pd.isna(df_out["resminfrac"]), "resmaxvolume"].values
-        )
-        df_out.loc[pd.isna(df_out["resfullfrac"]), "resfullfrac"] = (
-            df_EO.loc[pd.isna(df_out["resfullfrac"]), "capmax"].values
-            / df_out.loc[pd.isna(df_out["resfullfrac"]), "resmaxvolume"].values
-        )
+        mask = pd.isna(df_out["resminfrac"])
+        df_out.loc[mask, "resminfrac"] = df_EO.loc[mask, "capmin"].values.astype(
+            np.float64
+        ) / (df_out.loc[mask, "resmaxvolume"].values).astype(np.float64)
+
+        mask = pd.isna(df_out["resfullfrac"])
+        df_out.loc[mask, "resfullfrac"] = df_EO.loc[mask, "capmax"].values.astype(
+            np.float64
+        ) / (df_out.loc[mask, "resmaxvolume"].values).astype(np.float64)
 
     # rename to wflow naming convention
     tbls = {

--- a/hydromt_wflow/workflows/waterbodies.py
+++ b/hydromt_wflow/workflows/waterbodies.py
@@ -215,6 +215,7 @@ please use one of [gww, jrc] or None."
                 "resminfrac",
             ]
         ),
+        dtype=np.float32,
     )
     df_out["resid"] = gdf["waterbody_id"].values
 
@@ -324,21 +325,21 @@ please use one of [gww, jrc] or None."
 
     # Get resarea either from EO or database depending
     if "Area_avg" in gdf.columns:
-        df_out["resarea"] = gdf["Area_avg"].values.astype(np.float64)
+        df_out["resarea"] = gdf["Area_avg"].values.astype(np.float32)
         if timeseries_fn is not None:
             df_out.loc[pd.notna(df_EO["maxarea"]), "resarea"] = df_EO["maxarea"][
                 pd.notna(df_EO["maxarea"])
-            ].values.astype(np.float64)
+            ].values.astype(np.float32)
         else:
             df_out.loc[pd.isna(df_out["resarea"]), "resarea"] = df_EO["maxarea"][
                 pd.isna(df_out["resarea"])
-            ].values.astype(np.float64)
+            ].values.astype(np.float32)
     else:
-        df_out["resarea"] = df_EO["maxarea"].values.astype(np.float64)
+        df_out["resarea"] = df_EO["maxarea"].values.astype(np.float32)
 
     # Get resmaxvolume from database
     if "Vol_avg" in gdf.columns:
-        df_out["resmaxvolume"] = gdf["Vol_avg"].values.astype(np.float64)
+        df_out["resmaxvolume"] = gdf["Vol_avg"].values.astype(np.float32)
 
     # Compute target min and max fractions
     # First look if data is available from the database
@@ -500,12 +501,12 @@ please use one of [gww, jrc] or None."
         mask = pd.isna(df_out["resminfrac"])
         df_out.loc[mask, "resminfrac"] = df_EO.loc[mask, "capmin"].values.astype(
             np.float64
-        ) / (df_out.loc[mask, "resmaxvolume"].values).astype(np.float64)
+        ) / (df_out.loc[mask, "resmaxvolume"].values).astype(np.float32)
 
         mask = pd.isna(df_out["resfullfrac"])
         df_out.loc[mask, "resfullfrac"] = df_EO.loc[mask, "capmax"].values.astype(
             np.float64
-        ) / (df_out.loc[mask, "resmaxvolume"].values).astype(np.float64)
+        ) / (df_out.loc[mask, "resmaxvolume"].values).astype(np.float32)
 
     # rename to wflow naming convention
     tbls = {

--- a/pixi.lock
+++ b/pixi.lock
@@ -4609,7 +4609,7 @@ packages:
 - pypi: ./
   name: hydromt-wflow
   version: 1.0.0.dev0
-  sha256: 221dd3e01ddb76ec3a6d3655419920257bbd334e11f8ecea4b9bce4708c21699
+  sha256: 3c0013e4b2212c1054c2baec0a574afaa4c197cfcdc0451b5baf8eae1a5358ae
   requires_dist:
   - dask
   - geopandas>=0.10

--- a/pixi.lock
+++ b/pixi.lock
@@ -4608,8 +4608,8 @@ packages:
   requires_python: '>=3.9'
 - pypi: ./
   name: hydromt-wflow
-  version: 1.0.0rc1
-  sha256: 428835d8f48a7ef74c436ba9b4e8d3469d5c0f66d55ed68671da8518e79568a7
+  version: 1.0.0.dev0
+  sha256: 221dd3e01ddb76ec3a6d3655419920257bbd334e11f8ecea4b9bce4708c21699
   requires_dist:
   - dask
   - geopandas>=0.10

--- a/pixi.lock
+++ b/pixi.lock
@@ -4609,7 +4609,7 @@ packages:
 - pypi: ./
   name: hydromt-wflow
   version: 1.0.0.dev0
-  sha256: 3c0013e4b2212c1054c2baec0a574afaa4c197cfcdc0451b5baf8eae1a5358ae
+  sha256: ba6dca6aeedb29100a797417494aec6e95328a090565400a70b239577e9cc0bc
   requires_dist:
   - dask
   - geopandas>=0.10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,9 +80,7 @@ Source        = "https://github.com/Deltares/hydromt_wflow"
 filterwarnings = [
   # Can result in significant bugs, so we error on these
   "error::pandas.errors.SettingWithCopyWarning",
-  # "error:driver .* does not support open option:RuntimeWarning", # TODO investigate. ignore if not, else implement fix `Enable tracemalloc to get traceback where the object was allocated.`
-  # "error:Dataset has no geotransform, gcps, or rpcs. :rasterio.errors.NotGeoreferencedWarning", # TODO investigate. ignore if not, else implement fix. see https://github.com/rasterio/rasterio/issues/524
-  # check and resolve when hydromt v1 PR is done
+   # check and resolve when hydromt v1 PR is done
   "ignore::Warning:hydromt.*",
   "ignore::Warning:wradlib.*",
   "ignore:The staticmaps property:DeprecationWarning",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ filterwarnings = [
   "error::pandas.errors.SettingWithCopyWarning",
   "error:driver .* does not support open option:RuntimeWarning", # TODO investigate. ignore if not, else implement fix `Enable tracemalloc to get traceback where the object was allocated.`
   "error:Dataset has no geotransform, gcps, or rpcs. :rasterio.errors.NotGeoreferencedWarning", # TODO investigate. ignore if not, else implement fix. see https://github.com/rasterio/rasterio/issues/524
-  "error:Geometry is in a geographic CRS. Results from :UserWarning", # TODO investigate. ignore if not, else implement fix
+  "error:Geometry is in a geographic CRS. Results from :UserWarning",
   # check and resolve when hydromt v1 PR is done
   "ignore::Warning:hydromt.*",
   "ignore::Warning:wradlib.*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,9 +80,8 @@ Source        = "https://github.com/Deltares/hydromt_wflow"
 filterwarnings = [
   # Can result in significant bugs, so we error on these
   "error::pandas.errors.SettingWithCopyWarning",
-  "error:driver .* does not support open option:RuntimeWarning", # TODO investigate. ignore if not, else implement fix `Enable tracemalloc to get traceback where the object was allocated.`
-  "error:Dataset has no geotransform, gcps, or rpcs. :rasterio.errors.NotGeoreferencedWarning", # TODO investigate. ignore if not, else implement fix. see https://github.com/rasterio/rasterio/issues/524
-  "error:Geometry is in a geographic CRS. Results from :UserWarning",
+  # "error:driver .* does not support open option:RuntimeWarning", # TODO investigate. ignore if not, else implement fix `Enable tracemalloc to get traceback where the object was allocated.`
+  # "error:Dataset has no geotransform, gcps, or rpcs. :rasterio.errors.NotGeoreferencedWarning", # TODO investigate. ignore if not, else implement fix. see https://github.com/rasterio/rasterio/issues/524
   # check and resolve when hydromt v1 PR is done
   "ignore::Warning:hydromt.*",
   "ignore::Warning:wradlib.*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,9 +78,20 @@ Source        = "https://github.com/Deltares/hydromt_wflow"
 ## Pytest and coverage
 [tool.pytest.ini_options]
 filterwarnings = [
-  "ignore:distutils Version classes are deprecated:DeprecationWarning",
+  # Can result in significant bugs, so we error on these
+  "error::pandas.errors.SettingWithCopyWarning",
+  "error:driver .* does not support open option:RuntimeWarning", # TODO investigate. ignore if not, else implement fix `Enable tracemalloc to get traceback where the object was allocated.`
+  "error:Dataset has no geotransform, gcps, or rpcs. :rasterio.errors.NotGeoreferencedWarning", # TODO investigate. ignore if not, else implement fix. see https://github.com/rasterio/rasterio/issues/524
+  "error:Geometry is in a geographic CRS. Results from :UserWarning", # TODO investigate. ignore if not, else implement fix
+  # check and resolve when hydromt v1 PR is done
+  "ignore::Warning:hydromt.*",
+  "ignore::Warning:wradlib.*",
   "ignore:The staticmaps property:DeprecationWarning",
   "ignore:The staticgeoms property:DeprecationWarning",
+  "ignore:Using iterating over the DataCatalog directly is deprecated:DeprecationWarning",
+  # ignore below warnings, they are not raised in/caused by hydromt_wflow
+  "ignore:distutils Version classes are deprecated:DeprecationWarning",
+  "ignore:'AS-[A-Za-z]{3}' is deprecated.*:FutureWarning:xarray.groupers",
 ]
 testpaths = ["tests"]
 # don't run benchmarks by default when testing

--- a/tests/test_model_methods.py
+++ b/tests/test_model_methods.py
@@ -5,10 +5,8 @@ from itertools import product
 from os.path import abspath, dirname, isfile, join
 from pathlib import Path
 
+import geopandas as gpd
 import numpy as np
-
-# import warnings
-# import pdb
 import pandas as pd
 import pytest
 import xarray as xr
@@ -587,7 +585,7 @@ def test_setup_outlets(example_wflow_model):
     assert count[1] == 1
 
 
-def test_setup_gauges(example_wflow_model):
+def test_setup_gauges(example_wflow_model: WflowModel):
     # 1. Test with grdc data
     # uparea rename not in the latest artifact_data version
     example_wflow_model.data_catalog["grdc"].rename = {"area": "uparea"}
@@ -1357,7 +1355,9 @@ def test_setup_non_irrigation(example_wflow_model, tmpdir):
     assert "time" in example_wflow_model.grid["demand_domestic_net"].dims
 
 
-def test_setup_irrigation_nopaddy(example_wflow_model, tmpdir, globcover_gdf):
+def test_setup_irrigation_nopaddy(
+    example_wflow_model: WflowModel, tmpdir: Path, globcover_gdf: gpd.GeoDataFrame
+):
     # Read the data
     example_wflow_model.read()
     example_wflow_model.set_root(Path(tmpdir), mode="w")
@@ -1404,7 +1404,7 @@ def test_setup_irrigation_nopaddy(example_wflow_model, tmpdir, globcover_gdf):
 
     # Test with geodataframe
     # Use globcover gdf class 11
-    irrigation_gdf = globcover_gdf[globcover_gdf["landuse"].isin([14])]
+    irrigation_gdf = globcover_gdf.loc[globcover_gdf["landuse"].isin([14])]
     example_wflow_model.setup_irrigation_from_vector(
         irrigated_area_fn=irrigation_gdf,
         cropland_class=[11, 14, 20, 30],

--- a/tests/test_model_methods_sediment.py
+++ b/tests/test_model_methods_sediment.py
@@ -2,13 +2,18 @@
 
 from os.path import abspath, dirname, join
 
+import geopandas as gpd
 import numpy as np
+
+from hydromt_wflow.utils import planar_operation_in_utm
 
 TESTDATADIR = join(dirname(abspath(__file__)), "data")
 EXAMPLEDIR = join(dirname(abspath(__file__)), "..", "examples")
 
 
-def test_setup_lulc_sed(example_sediment_model, planted_forest_testdata):
+def test_setup_lulc_sed(
+    example_sediment_model, planted_forest_testdata: gpd.GeoDataFrame
+):
     example_sediment_model.setup_lulcmaps(
         lulc_fn="globcover_2009",
         lulc_mapping_fn="globcover_mapping_default",
@@ -18,9 +23,11 @@ def test_setup_lulc_sed(example_sediment_model, planted_forest_testdata):
         orchard_name="Orchard",
         orchard_c=0.2188,
     )
-    da = example_sediment_model.grid["erosion_usle_c"].raster.sample(
-        planted_forest_testdata.geometry.centroid
+
+    centroid = planar_operation_in_utm(
+        planted_forest_testdata, lambda geom: geom.centroid
     )
+    da = example_sediment_model.grid["erosion_usle_c"].raster.sample(centroid)
 
     # Strict equality checking is okay here because no processing is actually happening
     # and we want to make sure we don't add any rounding errors


### PR DESCRIPTION
## Issue addressed
Fixes #357 

## Explanation
using `filterwarnings` in pyproject.toml:
- I ignored warnings that should be looked at when we merge the v1 PR.
- We error on `SettingWithCopyWarning` from pandas that will error with pandas>3.0
- After spending some time on `NotGeoreferencedWarning` raised by rasterio, I have given up on this one. see https://github.com/rasterio/rasterio/issues/524
- Similarly, the RuntimeWarning `driver .* does not support open option` has to do with exceptions raised in the ogr backend of pyogrio. 

## Checklist
- [ ] Updated tests or added new tests
- [ ] Branch is up to date with `main`
- [ ] Tests & pre-commit hooks pass
- [ ] Updated documentation if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
