### PR TITLE
Feat/docs version switcher

### DIFF
--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -1,0 +1,87 @@
+[
+  {
+    "name": "v0.1.0",
+    "version": "v0.1.0",
+    "url": "https://deltares.github.io/hydromt_wflow/v0.1.0/"
+  },
+  {
+    "name": "v0.1.1",
+    "version": "v0.1.1",
+    "url": "https://deltares.github.io/hydromt_wflow/v0.1.1/"
+  },
+  {
+    "name": "v0.1.2",
+    "version": "v0.1.2",
+    "url": "https://deltares.github.io/hydromt_wflow/v0.1.2/"
+  },
+  {
+    "name": "v0.1.3",
+    "version": "v0.1.3",
+    "url": "https://deltares.github.io/hydromt_wflow/v0.1.3/"
+  },
+  {
+    "name": "v0.1.4",
+    "version": "v0.1.4",
+    "url": "https://deltares.github.io/hydromt_wflow/v0.1.4/"
+  },
+  {
+    "name": "v0.2.0",
+    "version": "v0.2.0",
+    "url": "https://deltares.github.io/hydromt_wflow/v0.2.0/"
+  },
+  {
+    "name": "v0.2.1",
+    "version": "v0.2.1",
+    "url": "https://deltares.github.io/hydromt_wflow/v0.2.1/"
+  },
+  {
+    "name": "v0.3.0",
+    "version": "v0.3.0",
+    "url": "https://deltares.github.io/hydromt_wflow/v0.3.0/"
+  },
+  {
+    "name": "v0.4.0",
+    "version": "v0.4.0",
+    "url": "https://deltares.github.io/hydromt_wflow/v0.4.0/"
+  },
+  {
+    "name": "v0.4.1",
+    "version": "v0.4.1",
+    "url": "https://deltares.github.io/hydromt_wflow/v0.4.1/"
+  },
+  {
+    "name": "v0.5.0",
+    "version": "v0.5.0",
+    "url": "https://deltares.github.io/hydromt_wflow/v0.5.0/"
+  },
+  {
+    "name": "v0.6.0",
+    "version": "v0.6.0",
+    "url": "https://deltares.github.io/hydromt_wflow/v0.6.0/"
+  },
+  {
+    "name": "v0.6.1",
+    "version": "v0.6.1",
+    "url": "https://deltares.github.io/hydromt_wflow/v0.6.1/"
+  },
+  {
+    "name": "v0.7.0",
+    "version": "v0.7.0",
+    "url": "https://deltares.github.io/hydromt_wflow/v0.7.0/"
+  },
+  {
+    "name": "v0.7.1",
+    "version": "v0.7.1",
+    "url": "https://deltares.github.io/hydromt_wflow/v0.7.1/"
+  },
+  {
+    "name": "v0.8.0",
+    "version": "v0.8.0",
+    "url": "https://deltares.github.io/hydromt_wflow/v0.8.0/"
+  },
+  {
+    "name": "v1.0.0rc1",
+    "version": "v1.0.0rc1",
+    "url": "https://deltares.github.io/hydromt_wflow/v1.0.0rc1/"
+  }
+]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,6 +46,9 @@ author = "Dirk Eilander"
 
 # The short version which is displayed
 version = hydromt_wflow.__version__
+bare_version = hydromt_wflow.__version__
+doc_version = bare_version[: bare_version.find("dev") - 1]
+
 
 # # -- Copy notebooks to include in docs -------
 if os.path.isdir("_examples"):
@@ -159,7 +162,11 @@ html_theme_options = {
     "logo": {
         "text": "HydroMT Wflow",
     },
-    "navbar_end": ["navbar-icon-links"],  # remove dark mode switch
+        "navbar_end": ["navbar-icon-links", "version-switcher"],  # remove dark mode switch
+    "switcher": {
+        "json_url": "https://raw.githubusercontent.com/Deltares/hydromt_wflow/gh-pages/switcher.json",
+        "version_match": doc_version,}
+
 }
 
 html_context = {


### PR DESCRIPTION
## Issue addressed
Fixes #520 

## Explanation
Fairly simple, just copied most code from core, and used some `jq` to generate the switcher from the tags. I also just went ahead and added them to the gh-pages branch otherwise they wouldn't work. This all works now. One downside ist hat there is no version switcher in the previous versions so if you choose a different version, you can't switch back without just going back in your browser history, but there's no way around that without having to regenerate all the documentation from all the versions, which is not worth it imo. 


## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [ ] Tests & pre-commit hooks pass
- [ ] Updated documentation if needed 
