### PR TITLE
fix: use contains_source instead of in datacatalog.sources for core v1

### DIFF
--- a/hydromt_wflow/wflow_sbm.py
+++ b/hydromt_wflow/wflow_sbm.py
@@ -779,7 +779,9 @@ setting new flood_depth dimensions"
                     i = fns_ids.index(_id)
                     rating_fn = rating_curve_fns[i]
                     # Read data
-                    if isfile(rating_fn) or rating_fn in self.data_catalog.sources:
+                    if isfile(rating_fn) or self.data_catalog.contains_source(
+                        rating_fn
+                    ):
                         logger.info(
                             f"Preparing reservoir rating curve data from {rating_fn}"
                         )


### PR DESCRIPTION
as described in the hydromt core migration guide

## Issue addressed
Fixes #<issue number>

## Explanation
Explain how you addressed the bug/feature request, what choices you made and why.

## Checklist
- [ ] Updated tests or added new tests
- [ ] Branch is up to date with `main`
- [ ] Tests & pre-commit hooks pass
- [ ] Updated documentation if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
