### PR TITLE
Changed cold start flag to true in model conversion code

### DIFF
--- a/hydromt_wflow/version_upgrade.py
+++ b/hydromt_wflow/version_upgrade.py
@@ -132,8 +132,10 @@ def _convert_to_wflow_v1(
     """
     if config["model"].get("reinit") == False:
         logger.warning(
-            "The 'reinit' option set to False is no longer supported in Wflow v1. "
-            "It will be converted to 'cold_start__flag = True'."
+            "Converting states is not supported by this conversion code, therefore the "
+            "reinit option (new name cold_start__flag) is adjusted to True. If model "
+            "states are required, please produce new states using a Wflow simulation or"
+            " use the setup_cold_states function."
         )
         config["model"]["reinit"] = True
     WFLOW_CONVERSION = _create_v0_to_v1_var_mapping(wflow_vars)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -102,11 +102,7 @@ def test_convert_to_wflow_v1_sbm(tmpdir, caplog):
     wflow.config.set("model.reinit", False)
     caplog.set_level(logging.WARNING)
     wflow.upgrade_to_v1_wflow()
-    assert (
-        "The 'reinit' option set to False is no longer supported in Wflow v1. "
-        "It will be converted to 'cold_start__flag = True'."
-    ) in caplog.text
-
+    assert "Converting states is not supported by this conversion code" in caplog.text
     assert wflow.config.get_value("model.cold_start__flag") is True
 
 


### PR DESCRIPTION
Added a check in _convert_to_wflow_v1 that checks if reinit is set to false and then logs a warning that this flag will be set to true because reinit=false is no longer supported in wflow v1. 

## Issue addressed
Fixes #633 

## Explanation
Explain how you addressed the bug/feature request, what choices you made and why.

## Checklist
- [ ] Updated tests or added new tests
- [ ] Branch is up to date with `main`
- [ ] Tests & pre-commit hooks pass
- [ ] Updated documentation if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
