### PR TITLE
Fixed error when clipping model states

### DIFF
--- a/hydromt_wflow/components/states.py
+++ b/hydromt_wflow/components/states.py
@@ -176,6 +176,9 @@ class WflowStatesComponent(GridComponent):
             filename=p_input,
             mask_and_scale=False,
         )
+        if not self.data.raster.crs:
+            logging.warning("CRS not found in states data, setting to model CRS.")
+            self.data.raster.set_crs(self.model.crs)
 
     @hydromt_step
     def write(self, filename: str | None = None):


### PR DESCRIPTION
## Issue addressed
Fixes #640 

## Explanation
I added a check to check if the states data has been read and set contains a crs. If not the states data is set as the model crs and a warning is logged that says the states data is using the model crs.

## Checklist
- [ ] Updated tests or added new tests
- [ ] Branch is up to date with `main`
- [ ] Tests & pre-commit hooks pass
- [ ] Updated documentation if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
