### PR TITLE
Mark tests that build / update / write the model as integration tests

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -5942,7 +5942,7 @@ packages:
 - pypi: ./
   name: hydromt-wflow
   version: 1.0.0.dev0
-  sha256: 3893ec1766dee72312461d4ed368ca2f0782e3016aeb87cd74af29dd3b6c905f
+  sha256: 72399a45bfd7e4b45a958ce315f665c512a4161aa3847022123c13bfe2a68dcc
   requires_dist:
   - dask
   - geopandas>=0.10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,7 @@ filterwarnings = [
 testpaths = ["tests"]
 # don't run benchmarks by default when testing
 addopts = ["--benchmark-skip"]
+markers = ["integration: marks tests as integration tests"]
 
 [tool.coverage.run]
 branch = true
@@ -357,20 +358,6 @@ build-example-models = {cmd = [
 [tool.pixi.feature.test.tasks]
 test = { cmd = ["pytest"] }
 test-lf = { cmd = ["pytest", "--lf", "--tb=short"] }
-test-cov = { cmd = [
-  "pytest",
-  "--verbose",
-  "--cov=hydromt_wflow",
-  "--cov-report",
-  "xml",
-] }
-test-cov-local = { cmd = [
-  "pytest",
-  "--verbose",
-  "--cov",
-  "--cov-report",
-  "html",
-] }
 build-test-model-simple = { cmd = [
   "hydromt",
   "build",
@@ -471,3 +458,17 @@ benchmark-compare = { cmd = [
   "--benchmark-compare",
   "--benchmark-compare-fail=min:25%",
 ] }
+
+[tool.pixi.feature.test.tasks.test-cov]
+cmd = [
+  "pytest",
+  "--verbose",
+  "--cov=hydromt_wflow",
+  "--cov-report={{ report }}",
+  "--cov-branch",
+  "-m",
+  "not integration",
+]
+args=[
+  { "arg" = "report", default="xml"}
+]

--- a/tests/test_model_class.py
+++ b/tests/test_model_class.py
@@ -66,6 +66,7 @@ def _compare_wflow_models(mod0: WflowBaseModel, mod1: WflowBaseModel):
 
 @pytest.mark.timeout(300)  # max 5 min
 @pytest.mark.parametrize("model", list(_supported_models.keys()))
+@pytest.mark.integration
 def test_model_build(tmpdir, model, example_models, example_inis):
     # get model type
     model_type = _supported_models[model]
@@ -112,6 +113,7 @@ def test_base_model_init_should_raise():
 
 
 @pytest.mark.timeout(60)  # max 1 min
+@pytest.mark.integration
 def test_model_clip(
     tmpdir: Path,
     example_wflow_model: WflowSbmModel,

--- a/tests/test_model_methods.py
+++ b/tests/test_model_methods.py
@@ -298,6 +298,7 @@ def test_setup_reservoirs_no_control(
 
 @pytest.mark.timeout(120)  # max 2 min
 @pytest.mark.parametrize("source", ["gww", "jrc"])
+@pytest.mark.integration
 def test_reservoirs_simple_control(source, tmpdir, example_wflow_model):
     # Read model 'wflow_piave_subbasin' from EXAMPLEDIR
     model = "wflow"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,6 +5,7 @@ from os.path import abspath, dirname, join
 from pathlib import Path
 
 import numpy as np
+import pytest
 
 from hydromt_wflow import WflowSbmModel, WflowSedimentModel
 from hydromt_wflow.utils import get_grid_from_config
@@ -202,6 +203,7 @@ def test_config_toml_overwrite(tmp_path: Path):
     assert dummy_model.config.get_value("path_log") == "log_file2.log"
 
 
+@pytest.mark.integration
 def test_convert_to_wflow_v1_with_lake_files(tmp_path: Path):
     # Initialize wflow model
     root = TESTDATADIR / "wflow_v0x" / "sbm_with_lake_files"


### PR DESCRIPTION
Update pyproject.toml task to default to xml, but easier to call it with html for local remove test-cov local. Instead call: pixi run test-cov html

This PR will drop code coverage from 82% to 75%.

## Checklist
- [ ] Updated tests or added new tests
- [ ] Branch is up to date with `main`
- [ ] Tests & pre-commit hooks pass
- [ ] Updated documentation if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
