### PR TITLE
Add integration tests back to test bench for PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,4 +62,4 @@ jobs:
           timeout_minutes: 10
           max_attempts: 3
           command: |
-            pixi run --locked -e test-full-py${{ matrix.python-version }} test-cov
+            pixi run --locked -e test-full-py${{ matrix.python-version }} test --verbose

--- a/pixi.lock
+++ b/pixi.lock
@@ -5942,7 +5942,7 @@ packages:
 - pypi: ./
   name: hydromt-wflow
   version: 1.0.0.dev0
-  sha256: 72399a45bfd7e4b45a958ce315f665c512a4161aa3847022123c13bfe2a68dcc
+  sha256: ae9ce8a7545774f7d1080b710f6babffc4d496d5d9977d08d8dcbfb490de20b0
   requires_dist:
   - dask
   - geopandas>=0.10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -462,7 +462,6 @@ benchmark-compare = { cmd = [
 [tool.pixi.feature.test.tasks.test-cov]
 cmd = [
   "pytest",
-  "--verbose",
   "--cov=hydromt_wflow",
   "--cov-report={{ report }}",
   "--cov-branch",


### PR DESCRIPTION
Only skip integration tests on test coverage.
Remove verbose flag from pixi tasks, instead added to the github action.

## Checklist
- [ ] Updated tests or added new tests
- [ ] Branch is up to date with `main`
- [ ] Tests & pre-commit hooks pass
- [ ] Updated documentation if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
