### PR TITLE
Fix: nodata val for interpolation

### DIFF
--- a/hydromt_wflow/workflows/demand.py
+++ b/hydromt_wflow/workflows/demand.py
@@ -500,7 +500,7 @@ def surfacewaterfrac_used(
     # create the dataarray for the fraction
     swfrac = xr.full_like(
         gwfrac_raw_mr,
-        fill_value=np.nan,
+        fill_value=-9999,
         dtype=np.float32,
     ).load()
     swfrac.name = "demand_surface_water_ratio"


### PR DESCRIPTION
## Issue addressed
Fixes small issue

## Explanation
By not having the fill value equal to the nodata value, interpolation is 'skipped' as no nodata values are encountered.
Just adjusted the fill value to be equal to the nodata value specified a few lines down. 

## Checklist
- [ ] Updated tests or added new tests
- [ ] Branch is up to date with `main`
- [ ] Tests & pre-commit hooks pass
- [ ] Updated documentation if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
