### PR TITLE
fix: add `river_depth_kwargs` as optional arg to `setup_rivers`

### DIFF
--- a/hydromt_wflow/wflow_base.py
+++ b/hydromt_wflow/wflow_base.py
@@ -478,6 +478,7 @@ skipping adding gauge specific outputs to the toml."
         min_rivwth: float = 30,
         rivdph_method: str | None = "powlaw",
         min_rivdph: float = 1,
+        river_depth_kwargs: dict | None = None,
         output_names: dict = {
             "river_location__mask": "river_mask",
             "river__length": "river_length",
@@ -557,6 +558,8 @@ skipping adding gauge specific outputs to the toml."
             Set to None to skip river depth estimation.
         min_rivdph : float, optional
             Minimum river depth [m], by default 1.0
+        river_depth_kwargs : dict, optional
+            Additional keyword arguments for river_depth method, by default None.
         output_names : dict, optional
             Dictionary with output names that will be used in the model netcdf input
             files. Users should provide the Wflow.jl variable name followed by the name
@@ -617,6 +620,7 @@ skipping adding gauge specific outputs to the toml."
                 smooth_len=smooth_len,
                 min_rivdph=min_rivdph,
                 min_rivwth=min_rivwth,
+                river_depth_kwargs=river_depth_kwargs,
             )
             rmdict = {k: self._MAPS.get(k, k) for k in ds_riv1.data_vars}
             self.staticmaps.set(ds_riv1.rename(rmdict))

--- a/hydromt_wflow/wflow_base.py
+++ b/hydromt_wflow/wflow_base.py
@@ -469,6 +469,7 @@ skipping adding gauge specific outputs to the toml."
     @hydromt_step
     def setup_rivers(
         self,
+        *,
         hydrography_fn: str | xr.Dataset,
         river_geom_fn: str | gpd.GeoDataFrame | None = None,
         river_upa: float = 30,

--- a/hydromt_wflow/wflow_sbm.py
+++ b/hydromt_wflow/wflow_sbm.py
@@ -102,6 +102,7 @@ class WflowSbmModel(WflowBaseModel):
             "river__slope": "river_slope",
             "river_bank_water__elevation": "river_bank_elevation",
         },
+        river_depth_kwargs: dict | None = None,
     ):
         """
         Set full river parameter maps including river depth and bank elevation.
@@ -198,6 +199,8 @@ class WflowSbmModel(WflowBaseModel):
             Dictionary with output names that will be used in the model netcdf input
             files. Users should provide the Wflow.jl variable name followed by the name
             in the netcdf file.
+        river_depth_kwargs : dict, optional
+            Additional keyword arguments for river_depth method, by default None.
 
         See Also
         --------
@@ -217,6 +220,7 @@ class WflowSbmModel(WflowBaseModel):
             rivdph_method=rivdph_method,
             min_rivdph=min_rivdph,
             output_names=output_names,
+            river_depth_kwargs=river_depth_kwargs,
         )
 
         routing_options = ["kinematic_wave", "local_inertial"]

--- a/hydromt_wflow/wflow_sediment.py
+++ b/hydromt_wflow/wflow_sediment.py
@@ -66,6 +66,7 @@ class WflowSedimentModel(WflowBaseModel):
             "river__width": "river_width",
             "river__slope": "river_slope",
         },
+        river_depth_kwargs: dict | None = None,
     ):
         """
         Set all river parameter maps.
@@ -136,6 +137,8 @@ class WflowSedimentModel(WflowBaseModel):
             Dictionary with output names that will be used in the model netcdf input
             files. Users should provide the Wflow.jl variable name followed by the name
             in the netcdf file.
+        river_depth_kwargs : dict, optional
+            Additional keyword arguments for river_depth method, by default None.
         """
         super().setup_rivers(
             hydrography_fn=hydrography_fn,
@@ -148,6 +151,7 @@ class WflowSedimentModel(WflowBaseModel):
             rivdph_method=None,
             min_rivdph=None,
             output_names=output_names,
+            river_depth_kwargs=river_depth_kwargs,
         )
 
     @hydromt_step

--- a/hydromt_wflow/workflows/river.py
+++ b/hydromt_wflow/workflows/river.py
@@ -197,6 +197,7 @@ def river_bathymetry(
     smooth_len: float = 5e3,
     min_rivdph: float = 1.0,
     min_rivwth: float = 30.0,
+    river_depth_kwargs: dict | None = None,
 ) -> xr.Dataset:
     """Get river width and optionally river depth/bankfull discharge.
 
@@ -217,6 +218,8 @@ def river_bathymetry(
         Minimum river depth [m], by default 1.0. Ignored if method=None.
     min_rivwth : float, optional
         Minimum river width [m], by default 30.0.
+    river_depth_kwargs : dict, optional
+        Additional keyword arguments for river_depth method, by default None.
 
     Returns
     -------
@@ -331,6 +334,7 @@ def river_bathymetry(
                 method=method,
                 min_rivdph=min_rivdph,
                 rivzs_name="subelv",
+                **(river_depth_kwargs or {}),
             )
             attrs = dict(_FillValue=-9999, unit="m")
             ds_model["rivdph"] = xr.Variable(dims, rivdph, attrs=attrs).fillna(-9999)

--- a/tests/test_model_methods.py
+++ b/tests/test_model_methods.py
@@ -2,6 +2,7 @@
 
 from itertools import product
 from pathlib import Path
+from unittest import mock
 
 import geopandas as gpd
 import numpy as np
@@ -11,6 +12,7 @@ import xarray as xr
 import xarray.testing as xrt
 from hydromt.data_catalog.sources import create_source
 from hydromt.gis import GeoDataset, full_like
+from hydromt.model.processes.rivers import river_depth
 from packaging.version import Version
 
 from hydromt_wflow import workflows
@@ -851,12 +853,25 @@ def test_setup_rivers_no_subgrid(tmp_path: Path):
             river_upa=30,
         )
 
-    # Now with correct hydrography
-    mod.setup_rivers(
-        hydrography_fn="merit_hydro_ihu",
-        river_geom_fn="hydro_rivers_lin",
-        river_upa=30,
-    )
+    # Now with correct hydrography and some additional kwargs for river depth
+    with mock.patch(
+        "hydromt_wflow.workflows.river.river_depth",
+        wraps=river_depth,
+    ) as mock_river_depth:
+        mod.setup_rivers(
+            hydrography_fn="merit_hydro_ihu",
+            river_geom_fn="hydro_rivers_lin",
+            river_upa=30,
+            river_depth_kwargs={"hc": 0.4, "hp": 0.9},
+        )
+        mock_river_depth.assert_called_once()
+        called_kwargs = mock_river_depth.call_args.kwargs
+
+        assert "hc" in called_kwargs
+        assert called_kwargs["hc"] == pytest.approx(0.4)
+
+        assert "hp" in called_kwargs
+        assert called_kwargs["hp"] == pytest.approx(0.9)
 
     assert "river_mask" in mod.staticmaps.data
 


### PR DESCRIPTION
## Issue addressed
Fixes #710 

## Explanation

`hydromt.model.processes.river_depth` already exposes `kwargs` that can be used like this. 
