### PR TITLE
Update split method to handle both paths and strings

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,6 +13,7 @@ New
 
 Fixed
 -----
+- Fixed `setup_reservoirs_no_control()` to be able to handle both strings and path objects. (#770)
 
 Removed
 -------

--- a/hydromt_wflow/wflow_sbm.py
+++ b/hydromt_wflow/wflow_sbm.py
@@ -770,7 +770,7 @@ setting new flood_depth dimensions"
             fns_ids = []
             for fn in rating_curve_fns:
                 try:
-                    fns_ids.append(int(str(fn).split("_")[-1].split(".")[0]))
+                    fns_ids.append(int(Path(fn).stem.split("_")[-1]))
                 except Exception:
                     logger.warning(
                         "Could not parse integer reservoir index from "


### PR DESCRIPTION
## Issue addressed
Fixes #742 

## Explanation
Replaced `fn.split(...)` with `Path(fn).stem.split(...)` as suggested so that the method can handle both strings and paths. 

## Checklist
- [ ] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [ ] Updated documentation if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
