### PR TITLE
Fix cells outside domain

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,6 +16,7 @@ Fixed
 -----
 - Fixed `setup_reservoirs_no_control()` to be able to handle both strings and path objects. (#770)
 - Fixed outdated imports in ``hydromt_wflow.components.staticmaps``. (#782)
+- Fixed `hydrography` workflow to correctly remove no data values outside of the model region. (#785)
 
 Removed
 -------

--- a/hydromt_wflow/workflows/basemaps.py
+++ b/hydromt_wflow/workflows/basemaps.py
@@ -169,17 +169,21 @@ parametrization of distributed hydrological models.
         # derive basins
         if np.any(outbas_pit != 0):
             idxs_pit = idxs_pit0[outbas_pit != 0]
-            basins = flwdir_out.basins(idxs=idxs_pit).astype(np.int32)
-            ds_out.coords["mask"] = xr.Variable(
-                dims=ds_out.raster.dims, data=basins != 0, attrs=dict(_FillValue=0)
-            )
+
         else:
-            # This is a patch for basins which are clipped based on bbox or wrong geom
+            # Basins which are clipped based on bbox or wrong geom
             mask_int = ds["mask"].astype(np.int8)
             mask_int.raster.set_nodata(-1)
             mask_reproj = mask_int.raster.reproject_like(da_flw, method="nearest")
             mask_out = mask_reproj.values > 0
             ds_out.coords["mask"] = xr.Variable(dims=ds_out.raster.dims, data=mask_out)
+            idxs_pit = flwdir_out.outflow_idxs(mask_out)
+
+        # Delineate basins from upscaled outflow cells.
+        basins = flwdir_out.basins(idxs=idxs_pit).astype(np.int32)
+        ds_out.coords["mask"] = xr.Variable(
+            dims=ds_out.raster.dims, data=basins != 0, attrs=dict(_FillValue=0)
+        )
 
         ds_out[basins_name] = xr.Variable(dims, basins, attrs=dict(_FillValue=0))
         # calculate upstream area using subgrid ucat cell areas

--- a/hydromt_wflow/workflows/basemaps.py
+++ b/hydromt_wflow/workflows/basemaps.py
@@ -266,7 +266,7 @@ parametrization of distributed hydrological models.
         ds_out[strord_name].raster.set_nodata(255)
 
     # clip to basin extent
-    ds_out = ds_out.raster.clip_mask(da_mask=ds_out[basins_name], mask=True)
+    ds_out = ds_out.raster.clip_mask(da_mask=ds_out[basins_name])
     # also mask idx_out coords if present
     if "idx_out" in ds_out:
         ds_out["idx_out"] = ds_out["idx_out"].where(

--- a/hydromt_wflow/workflows/basemaps.py
+++ b/hydromt_wflow/workflows/basemaps.py
@@ -183,11 +183,11 @@ parametrization of distributed hydrological models.
 
             # Delineate basins from upscaled outflow cells of the fallback mask.
             idxs_pit = flwdir_out.outflow_idxs(mask_out)
-            if idxs_pit.size > 0:
-                basins = flwdir_out.basins(idxs=idxs_pit).astype(np.int32)
-                ds_out.coords["mask"] = xr.Variable(
-                    dims=ds_out.raster.dims, data=basins != 0, attrs=dict(_FillValue=0)
-                )
+            basins = flwdir_out.basins(idxs=idxs_pit).astype(np.int32)
+            ds_out.coords["mask"] = xr.Variable(
+                dims=ds_out.raster.dims, data=basins != 0, attrs=dict(_FillValue=0)
+            )
+
         ds_out[basins_name] = xr.Variable(dims, basins, attrs=dict(_FillValue=0))
         # calculate upstream area using subgrid ucat cell areas
         outidx = np.where(
@@ -451,14 +451,8 @@ def parse_region(
         raise ValueError("wflow region geometry has no CRS")
 
     # Set the basins geometry
-    ds_org = ds_org.raster.clip_geom(geom, align=resolution, buffer=10, mask=True)
-
-    if "mask" not in ds_org.coords:
-        logger.warning(
-            "No mask coordinate found in the hydrography dataset, "
-            "creating one based on the region geometry. "
-        )
-        ds_org.coords["mask"] = ds_org.raster.geometry_mask(geom)
+    ds_org = ds_org.raster.clip_geom(geom, align=resolution, buffer=10)
+    ds_org.coords["mask"] = ds_org.raster.geometry_mask(geom)
 
     geometries = {}
     if not math.isclose(scale_ratio, 1):

--- a/hydromt_wflow/workflows/basemaps.py
+++ b/hydromt_wflow/workflows/basemaps.py
@@ -181,13 +181,6 @@ parametrization of distributed hydrological models.
             mask_out = mask_reproj.values > 0
             ds_out.coords["mask"] = xr.Variable(dims=ds_out.raster.dims, data=mask_out)
 
-            # Delineate basins from upscaled outflow cells of the fallback mask.
-            idxs_pit = flwdir_out.outflow_idxs(mask_out)
-            basins = flwdir_out.basins(idxs=idxs_pit).astype(np.int32)
-            ds_out.coords["mask"] = xr.Variable(
-                dims=ds_out.raster.dims, data=basins != 0, attrs=dict(_FillValue=0)
-            )
-
         ds_out[basins_name] = xr.Variable(dims, basins, attrs=dict(_FillValue=0))
         # calculate upstream area using subgrid ucat cell areas
         outidx = np.where(

--- a/hydromt_wflow/workflows/basemaps.py
+++ b/hydromt_wflow/workflows/basemaps.py
@@ -266,7 +266,7 @@ parametrization of distributed hydrological models.
         ds_out[strord_name].raster.set_nodata(255)
 
     # clip to basin extent
-    ds_out = ds_out.raster.clip_mask(da_mask=ds_out[basins_name])
+    ds_out = ds_out.raster.clip_mask(da_mask=ds_out[basins_name], mask=True)
     # also mask idx_out coords if present
     if "idx_out" in ds_out:
         ds_out["idx_out"] = ds_out["idx_out"].where(
@@ -448,8 +448,14 @@ def parse_region(
         raise ValueError("wflow region geometry has no CRS")
 
     # Set the basins geometry
-    ds_org = ds_org.raster.clip_geom(geom, align=resolution, buffer=10)
-    ds_org.coords["mask"] = ds_org.raster.geometry_mask(geom)
+    ds_org = ds_org.raster.clip_geom(geom, align=resolution, buffer=10, mask=True)
+
+    if "mask" not in ds_org.coords:
+        logger.warning(
+            "No mask coordinate found in the hydrography dataset, "
+            "creating one based on the region geometry. "
+        )
+        ds_org.coords["mask"] = ds_org.raster.geometry_mask(geom)
 
     geometries = {}
     if not math.isclose(scale_ratio, 1):

--- a/hydromt_wflow/workflows/basemaps.py
+++ b/hydromt_wflow/workflows/basemaps.py
@@ -176,15 +176,18 @@ parametrization of distributed hydrological models.
         else:
             # This is a patch for basins which are clipped based on bbox or wrong geom
             mask_int = ds["mask"].astype(np.int8)
-            mask_int.raster.set_nodata(-1)  # change nodata value
-            ds_out.coords["mask"] = mask_int.raster.reproject_like(
-                da_flw, method="nearest"
-            ).astype(bool)
-            basins = ds_out["mask"].values.astype(np.int32)
-            logger.warning(
-                "The basin delineation might be wrong as no original resolution outlets"
-                " are found in the upscaled map."
-            )
+            mask_int.raster.set_nodata(-1)
+            mask_reproj = mask_int.raster.reproject_like(da_flw, method="nearest")
+            mask_out = mask_reproj.values > 0
+            ds_out.coords["mask"] = xr.Variable(dims=ds_out.raster.dims, data=mask_out)
+
+            # Delineate basins from upscaled outflow cells of the fallback mask.
+            idxs_pit = flwdir_out.outflow_idxs(mask_out)
+            if idxs_pit.size > 0:
+                basins = flwdir_out.basins(idxs=idxs_pit).astype(np.int32)
+                ds_out.coords["mask"] = xr.Variable(
+                    dims=ds_out.raster.dims, data=basins != 0, attrs=dict(_FillValue=0)
+                )
         ds_out[basins_name] = xr.Variable(dims, basins, attrs=dict(_FillValue=0))
         # calculate upstream area using subgrid ucat cell areas
         outidx = np.where(


### PR DESCRIPTION
## Issue addressed
Fixes #752 

## Explanation
The column filled with values instead of NaNs was traced back to nodata values outside of the domain being set to "True" when creating a mask for basins defined by "bbox" or "geom'. Now a mask is created by taking values above zero as active cells, which seems to also resolve the issue of the domain being too large too. 

## Checklist
- [ ] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [ ] Updated documentation if needed

## Additional Notes (optional)
It was difficult to pinpoint the issue due to the complexity of the hydrography function and its interactions with parse_region() and other clipping methods. We should consider some refactoring and clearer documentation for it in the future (#786). 
