### PR TITLE
Rebuild example models on windows and linux using gh actions

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -1,5 +1,5 @@
 ---
-name: Rebuild artifacts
+name: Build artifacts
 
 permissions:
   contents: write

--- a/.github/workflows/rebuild-example-data.yml
+++ b/.github/workflows/rebuild-example-data.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       branch:
-        description: "Branch to rebuild and commit artifacts to"
+        description: "Branch to rebuild and commit artifacts to. Protected branches `main` and `release/*` are not allowed"
         required: true
         type: string
       pixi-task:

--- a/.github/workflows/rebuild-example-data.yml
+++ b/.github/workflows/rebuild-example-data.yml
@@ -1,0 +1,156 @@
+---
+name: Rebuild artifacts
+
+permissions:
+  contents: write
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch to rebuild and commit artifacts to"
+        required: true
+        type: string
+      pixi-task:
+        description: "Pixi task to run"
+        required: true
+        default: "build-example-models"
+        type: string
+      pixi-environment:
+        description: "Pixi environment used to run the task"
+        required: true
+        default: "default"
+        type: string
+      runner-matrix:
+        description: "JSON array of runner os"
+        required: true
+        default: '["ubuntu-latest","windows-latest"]'
+        type: string
+      artifact-name:
+        description: "Artifact name prefix for uploaded outputs"
+        required: true
+        default: "rebuilt-artifacts"
+        type: string
+      upload-paths-linux:
+        description: "Newline-separated Linux paths to upload"
+        required: true
+        default: |
+          examples/linux64/wflow_piave_subbasin/**
+          examples/linux64/wflow_sediment_piave_subbasin/**
+          examples/linux64/wflow_piave_clip/**
+        type: string
+      upload-paths-windows:
+        description: "Newline-separated Windows paths to upload"
+        required: true
+        default: |
+          examples/wflow_piave_subbasin/**
+          examples/wflow_sediment_piave_subbasin/**
+          examples/wflow_piave_clip/**
+        type: string
+      commit-paths:
+        description: "Newline-separated paths to stage and commit"
+        required: true
+        default: |
+          examples/wflow_piave_subbasin
+          examples/wflow_sediment_piave_subbasin
+          examples/wflow_piave_clip
+          examples/linux64/wflow_piave_subbasin
+          examples/linux64/wflow_sediment_piave_subbasin
+          examples/linux64/wflow_piave_clip
+        type: string
+      commit-message:
+        description: "Commit message for rebuilt outputs"
+        required: true
+        default: "Rebuild artifacts"
+        type: string
+
+jobs:
+  rebuild-artifacts:
+    defaults:
+      run:
+        shell: bash -l {0}
+    name: Rebuild artifacts - ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ${{ fromJson(inputs.runner-matrix) }}
+
+    runs-on: ${{ matrix.os }}
+    concurrency:
+      group: ${{ github.workflow }}-${{ matrix.os }}-${{ inputs.branch }}
+      cancel-in-progress: true
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Setup pixi
+        uses: prefix-dev/setup-pixi@v0.10.0
+        with:
+          pixi-version: "v0.72.0"
+          environments: ${{ inputs.pixi-environment }}
+          activate-environment: true
+          frozen: true
+          cache: true
+
+      - name: Rebuild artifacts
+        run: pixi run --no-install -e ${{ inputs.pixi-environment }} ${{ inputs.pixi-task }}
+
+      - name: Upload rebuilt artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ inputs.artifact-name }}-${{ matrix.os }}
+          if-no-files-found: error
+          path: ${{ matrix.os == 'windows-latest' && inputs.upload-paths-windows || inputs.upload-paths-linux }}
+
+  commit-rebuilt-artifacts:
+    name: Commit rebuilt artifacts
+    needs: rebuild-artifacts
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+    concurrency:
+      group: ${{ github.workflow }}-commit-${{ inputs.branch }}
+      cancel-in-progress: true
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.branch }}
+          fetch-depth: 0
+
+      - name: Download rebuilt artifacts
+        uses: actions/download-artifact@v8
+        with:
+          pattern: ${{ inputs.artifact-name }}-*
+          path: .
+          merge-multiple: true
+
+      - name: Detect and stage changes
+        id: stage
+        run: |
+          while IFS= read -r path; do
+            if [ -n "$path" ]; then
+              git add "$path"
+            fi
+          done <<< "${{ inputs.commit-paths }}"
+
+          if git diff --cached --quiet; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit rebuilt artifacts
+        if: ${{ steps.stage.outputs.has_changes == 'true' }}
+        run: |
+          git config user.name "GitHub Actions Bot"
+          git config user.email "<github-actions[bot]@users.noreply.github.com>"
+          git commit -m "${{ inputs.commit-message }}"
+
+      - name: Push changes
+        if: ${{ steps.stage.outputs.has_changes == 'true' }}
+        run: git push origin HEAD:${{ inputs.branch }}

--- a/.github/workflows/rebuild-example-data.yml
+++ b/.github/workflows/rebuild-example-data.yml
@@ -5,8 +5,6 @@ permissions:
   contents: write
 
 on:
-  push:
-    branches: [feat/add-rebuild-artifacts-workflow]
   workflow_dispatch:
     inputs:
       branch:
@@ -67,7 +65,23 @@ on:
         type: string
 
 jobs:
+  validate-branch:
+    name: Validate target branch
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+      - name: Block protected branches
+        run: |
+          branch="${{ inputs.branch }}"
+          if [ "$branch" = "main" ] || [[ "$branch" == release/* ]]; then
+            echo "Refusing to run on protected branch: $branch"
+            exit 1
+          fi
+
   rebuild-artifacts:
+    needs: validate-branch
     defaults:
       run:
         shell: bash -l {0}
@@ -75,82 +89,37 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ${{ fromJson(inputs.runner-matrix || '["ubuntu-latest","windows-latest"]') }}
+        os: ${{ fromJson(inputs.runner-matrix) }}
 
     runs-on: ${{ matrix.os }}
     concurrency:
-      group: ${{ github.workflow }}-${{ matrix.os }}-${{ inputs.branch || github.ref_name }}
+      group: ${{ github.workflow }}-${{ matrix.os }}-${{ inputs.branch }}
       cancel-in-progress: true
 
     steps:
-      - name: Resolve parameters
-        id: params
-        run: |
-          branch="${{ inputs.branch }}"
-          if [ -z "$branch" ]; then
-            branch="${GITHUB_REF_NAME}"
-          fi
-
-          pixi_environment="${{ inputs.pixi-environment }}"
-          if [ -z "$pixi_environment" ]; then
-            pixi_environment="default"
-          fi
-
-          pixi_task="${{ inputs.pixi-task }}"
-          if [ -z "$pixi_task" ]; then
-            pixi_task="build-example-models"
-          fi
-
-          artifact_name="${{ inputs.artifact-name }}"
-          if [ -z "$artifact_name" ]; then
-            artifact_name="rebuilt-artifacts"
-          fi
-
-          if [ "${{ matrix.os }}" = "windows-latest" ]; then
-            upload_paths="${{ inputs.upload-paths-windows }}"
-            if [ -z "$upload_paths" ]; then
-              upload_paths=$'examples/wflow_piave_subbasin/**\nexamples/wflow_sediment_piave_subbasin/**\nexamples/wflow_piave_clip/**'
-            fi
-          else
-            upload_paths="${{ inputs.upload-paths-linux }}"
-            if [ -z "$upload_paths" ]; then
-              upload_paths=$'examples/linux64/wflow_piave_subbasin/**\nexamples/linux64/wflow_sediment_piave_subbasin/**\nexamples/linux64/wflow_piave_clip/**'
-            fi
-          fi
-
-          {
-            echo "branch=$branch"
-            echo "pixi_environment=$pixi_environment"
-            echo "pixi_task=$pixi_task"
-            echo "artifact_name=$artifact_name"
-            echo "upload_paths<<EOF"
-            printf "%s\n" "$upload_paths"
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
-
       - name: Checkout source
         uses: actions/checkout@v7
         with:
-          ref: ${{ steps.params.outputs.branch }}
+          ref: ${{ inputs.branch }}
 
       - name: Setup pixi
         uses: prefix-dev/setup-pixi@v0.10.0
         with:
           pixi-version: "v0.72.0"
-          environments: ${{ steps.params.outputs.pixi_environment }}
+          environments: ${{ inputs.pixi-environment }}
           activate-environment: true
           frozen: true
           cache: true
 
       - name: Rebuild artifacts
-        run: pixi run --no-install -e ${{ steps.params.outputs.pixi_environment }} ${{ steps.params.outputs.pixi_task }}
+        run: pixi run --no-install -e ${{ inputs.pixi-environment }} ${{ inputs.pixi-task }}
 
       - name: Upload rebuilt artifacts
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ steps.params.outputs.artifact_name }}-${{ matrix.os }}
+          name: ${{ inputs.artifact-name }}-${{ matrix.os }}
           if-no-files-found: error
-          path: ${{ steps.params.outputs.upload_paths }}
+          path: ${{ matrix.os == 'windows-latest' && inputs.upload-paths-windows || inputs.upload-paths-linux }}
 
   commit-rebuilt-artifacts:
     name: Commit rebuilt artifacts
@@ -160,51 +129,19 @@ jobs:
       run:
         shell: bash -l {0}
     concurrency:
-      group: ${{ github.workflow }}-commit-${{ inputs.branch || github.ref_name }}
+      group: ${{ github.workflow }}-commit-${{ inputs.branch }}
       cancel-in-progress: true
     steps:
-      - name: Resolve parameters
-        id: params
-        run: |
-          branch="${{ inputs.branch }}"
-          if [ -z "$branch" ]; then
-            branch="${GITHUB_REF_NAME}"
-          fi
-
-          artifact_name="${{ inputs.artifact-name }}"
-          if [ -z "$artifact_name" ]; then
-            artifact_name="rebuilt-artifacts"
-          fi
-
-          commit_paths="${{ inputs.commit-paths }}"
-          if [ -z "$commit_paths" ]; then
-            commit_paths=$'examples/wflow_piave_subbasin\nexamples/wflow_sediment_piave_subbasin\nexamples/wflow_piave_clip\nexamples/linux64/wflow_piave_subbasin\nexamples/linux64/wflow_sediment_piave_subbasin\nexamples/linux64/wflow_piave_clip'
-          fi
-
-          commit_message="${{ inputs.commit-message }}"
-          if [ -z "$commit_message" ]; then
-            commit_message="Rebuild artifacts"
-          fi
-
-          {
-            echo "branch=$branch"
-            echo "artifact_name=$artifact_name"
-            echo "commit_paths<<EOF"
-            printf "%s\n" "$commit_paths"
-            echo "EOF"
-            echo "commit_message=$commit_message"
-          } >> "$GITHUB_OUTPUT"
-
       - name: Checkout source
         uses: actions/checkout@v7
         with:
-          ref: ${{ steps.params.outputs.branch }}
+          ref: ${{ inputs.branch }}
           fetch-depth: 0
 
       - name: Download rebuilt artifacts
         uses: actions/download-artifact@v8
         with:
-          pattern: ${{ steps.params.outputs.artifact_name }}-*
+          pattern: ${{ inputs.artifact-name }}-*
           path: .
           merge-multiple: true
 
@@ -215,12 +152,14 @@ jobs:
             if [ -n "$path" ]; then
               git add "$path"
             fi
-          done <<< "${{ steps.params.outputs.commit_paths }}"
+          done <<< "${{ inputs.commit-paths }}"
 
           if git diff --cached --quiet; then
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "No changes found, skipping commit and push"
           else
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            echo "Found changes, commiting and pushing"
           fi
 
       - name: Commit rebuilt artifacts
@@ -228,8 +167,8 @@ jobs:
         run: |
           git config user.name "GitHub Actions Bot"
           git config user.email "<github-actions[bot]@users.noreply.github.com>"
-          git commit -m "${{ steps.params.outputs.commit_message }}"
+          git commit -m "${{ inputs.commit-message }}"
 
       - name: Push changes
         if: ${{ steps.stage.outputs.has_changes == 'true' }}
-        run: git push origin HEAD:${{ steps.params.outputs.branch }}
+        run: git push origin HEAD:${{ inputs.branch }}

--- a/.github/workflows/rebuild-example-data.yml
+++ b/.github/workflows/rebuild-example-data.yml
@@ -75,37 +75,82 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ${{ fromJson(inputs.runner-matrix) }}
+        os: ${{ fromJson(inputs.runner-matrix || '["ubuntu-latest","windows-latest"]') }}
 
     runs-on: ${{ matrix.os }}
     concurrency:
-      group: ${{ github.workflow }}-${{ matrix.os }}-${{ inputs.branch }}
+      group: ${{ github.workflow }}-${{ matrix.os }}-${{ inputs.branch || github.ref_name }}
       cancel-in-progress: true
 
     steps:
+      - name: Resolve parameters
+        id: params
+        run: |
+          branch="${{ inputs.branch }}"
+          if [ -z "$branch" ]; then
+            branch="${GITHUB_REF_NAME}"
+          fi
+
+          pixi_environment="${{ inputs.pixi-environment }}"
+          if [ -z "$pixi_environment" ]; then
+            pixi_environment="default"
+          fi
+
+          pixi_task="${{ inputs.pixi-task }}"
+          if [ -z "$pixi_task" ]; then
+            pixi_task="build-example-models"
+          fi
+
+          artifact_name="${{ inputs.artifact-name }}"
+          if [ -z "$artifact_name" ]; then
+            artifact_name="rebuilt-artifacts"
+          fi
+
+          if [ "${{ matrix.os }}" = "windows-latest" ]; then
+            upload_paths="${{ inputs.upload-paths-windows }}"
+            if [ -z "$upload_paths" ]; then
+              upload_paths=$'examples/wflow_piave_subbasin/**\nexamples/wflow_sediment_piave_subbasin/**\nexamples/wflow_piave_clip/**'
+            fi
+          else
+            upload_paths="${{ inputs.upload-paths-linux }}"
+            if [ -z "$upload_paths" ]; then
+              upload_paths=$'examples/linux64/wflow_piave_subbasin/**\nexamples/linux64/wflow_sediment_piave_subbasin/**\nexamples/linux64/wflow_piave_clip/**'
+            fi
+          fi
+
+          {
+            echo "branch=$branch"
+            echo "pixi_environment=$pixi_environment"
+            echo "pixi_task=$pixi_task"
+            echo "artifact_name=$artifact_name"
+            echo "upload_paths<<EOF"
+            printf "%s\n" "$upload_paths"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Checkout source
         uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.branch }}
+          ref: ${{ steps.params.outputs.branch }}
 
       - name: Setup pixi
         uses: prefix-dev/setup-pixi@v0.10.0
         with:
           pixi-version: "v0.72.0"
-          environments: ${{ inputs.pixi-environment }}
+          environments: ${{ steps.params.outputs.pixi_environment }}
           activate-environment: true
           frozen: true
           cache: true
 
       - name: Rebuild artifacts
-        run: pixi run --no-install -e ${{ inputs.pixi-environment }} ${{ inputs.pixi-task }}
+        run: pixi run --no-install -e ${{ steps.params.outputs.pixi_environment }} ${{ steps.params.outputs.pixi_task }}
 
       - name: Upload rebuilt artifacts
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ inputs.artifact-name }}-${{ matrix.os }}
+          name: ${{ steps.params.outputs.artifact_name }}-${{ matrix.os }}
           if-no-files-found: error
-          path: ${{ matrix.os == 'windows-latest' && inputs.upload-paths-windows || inputs.upload-paths-linux }}
+          path: ${{ steps.params.outputs.upload_paths }}
 
   commit-rebuilt-artifacts:
     name: Commit rebuilt artifacts
@@ -115,19 +160,51 @@ jobs:
       run:
         shell: bash -l {0}
     concurrency:
-      group: ${{ github.workflow }}-commit-${{ inputs.branch }}
+      group: ${{ github.workflow }}-commit-${{ inputs.branch || github.ref_name }}
       cancel-in-progress: true
     steps:
+      - name: Resolve parameters
+        id: params
+        run: |
+          branch="${{ inputs.branch }}"
+          if [ -z "$branch" ]; then
+            branch="${GITHUB_REF_NAME}"
+          fi
+
+          artifact_name="${{ inputs.artifact-name }}"
+          if [ -z "$artifact_name" ]; then
+            artifact_name="rebuilt-artifacts"
+          fi
+
+          commit_paths="${{ inputs.commit-paths }}"
+          if [ -z "$commit_paths" ]; then
+            commit_paths=$'examples/wflow_piave_subbasin\nexamples/wflow_sediment_piave_subbasin\nexamples/wflow_piave_clip\nexamples/linux64/wflow_piave_subbasin\nexamples/linux64/wflow_sediment_piave_subbasin\nexamples/linux64/wflow_piave_clip'
+          fi
+
+          commit_message="${{ inputs.commit-message }}"
+          if [ -z "$commit_message" ]; then
+            commit_message="Rebuild artifacts"
+          fi
+
+          {
+            echo "branch=$branch"
+            echo "artifact_name=$artifact_name"
+            echo "commit_paths<<EOF"
+            printf "%s\n" "$commit_paths"
+            echo "EOF"
+            echo "commit_message=$commit_message"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Checkout source
         uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.branch }}
+          ref: ${{ steps.params.outputs.branch }}
           fetch-depth: 0
 
       - name: Download rebuilt artifacts
         uses: actions/download-artifact@v8
         with:
-          pattern: ${{ inputs.artifact-name }}-*
+          pattern: ${{ steps.params.outputs.artifact_name }}-*
           path: .
           merge-multiple: true
 
@@ -138,7 +215,7 @@ jobs:
             if [ -n "$path" ]; then
               git add "$path"
             fi
-          done <<< "${{ inputs.commit-paths }}"
+          done <<< "${{ steps.params.outputs.commit_paths }}"
 
           if git diff --cached --quiet; then
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
@@ -151,8 +228,8 @@ jobs:
         run: |
           git config user.name "GitHub Actions Bot"
           git config user.email "<github-actions[bot]@users.noreply.github.com>"
-          git commit -m "${{ inputs.commit-message }}"
+          git commit -m "${{ steps.params.outputs.commit_message }}"
 
       - name: Push changes
         if: ${{ steps.stage.outputs.has_changes == 'true' }}
-        run: git push origin HEAD:${{ inputs.branch }}
+        run: git push origin HEAD:${{ steps.params.outputs.branch }}

--- a/.github/workflows/rebuild-example-data.yml
+++ b/.github/workflows/rebuild-example-data.yml
@@ -5,6 +5,8 @@ permissions:
   contents: write
 
 on:
+  push:
+    branches: [feat/add-rebuild-artifacts-workflow]
   workflow_dispatch:
     inputs:
       branch:

--- a/.teamcity/patches/buildTypes/SystemTestLatestRelease.kts
+++ b/.teamcity/patches/buildTypes/SystemTestLatestRelease.kts
@@ -35,4 +35,3 @@ create(DslContext.projectId, BuildType({
         }
     }
 }))
-


### PR DESCRIPTION
This workflow allows for the running of a pixi task and commiting its artifacts to any non-protected branch if there are any on the specified paths. (see inputs for all config options)

## Explanation

Currently, when things change, resulting in a difference in staticmaps, but we check and validate that the change is actually correct and expected, we need to update the example models / other artifacts on all supported platforms manually.

I made the inputs for the workflow configurable so we should be able to run different pixi tasks that regenerate other artifacts as well.

To test it, I added a push trigger with default values for all of the arguments, essentially the same as running with workflow dispatch and changing nothing.
For a successful run, see the action runs for this commit: [add testing code so push trigger works](https://github.com/Deltares/hydromt_wflow/pull/803/commits/9fcd9c95bf958de604060a69dba34a0c42f50101)

I have since removed the push trigger and the default param resolution, since we only want to run on request.