### PR TITLE
Change installation guide to use uv and pixi

### DIFF
--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -14,17 +14,23 @@ We recommend installing HydroMT-Wflow in a dedicated Python environment to ensur
 Prerequisite: Python installation
 =================================
 
-You will need **Python 3.11 or greater** and a package manager such as uv, pixi, or others in order to use HydroMT-Wflow. 
+You will need **Python 3.11 or greater** and a package manager such as uv, pixi, or others in order to use HydroMT-Wflow.
 These package managers help you to install (Python) packages and manage environments such that different installations do not conflict.
 
 If you do not yet have one installed, we recommend either:
 
 - `uv <https://docs.astral.sh/uv/>`_: uses `pypi.org <https://pypi.org>`_ for downloading dependencies.
-- `pixi <https://pixi.sh>`_: uses `conda-forge <https://conda-forge.org/>`_ for downloading dependencies.
+- `pixi <https://pixi.sh>`_: by default uses `conda-forge <https://conda-forge.org/>`_ for downloading dependencies,
+but will also search `pypi.org <https://pypi.org>`_ for dependencies it cannot find on conda-forge.
 
 It is also possible to use other package managers, such as pip or conda.
 The benefits of uv and pixi over pip and conda are that they install Python directly in the project folder,
 which avoids conflicts with other packages and allows you to have multiple versions of Python installed on your system.
+They work differently to conda/pip, where the typical workflow is to activate a named environment first
+(for example with ``conda activate <env>``), and then run installation and CLI commands from that active environment.
+In uv and pixi, project environment management is tied to the project folder itself and is integrated into one tool-driven
+workflow and commands are typically run through the project tool (for example ``pixi run ...`` or ``uv run ...``).
+
 
 Installing HydroMT-Wflow
 ========================
@@ -46,9 +52,9 @@ Therefore we use uv or pixi to create a new project folder with Python directly 
 
     .. code-block:: console
 
-      $ uv init my_hydromt_wflow
-      $ cd my_hydromt_wflow
-      $ uv add hydromt_wflow
+      $ uv init my_project
+      $ cd my_project
+      $ uv add project
       $ uv sync
 
     .. note::
@@ -60,12 +66,12 @@ Therefore we use uv or pixi to create a new project folder with Python directly 
 
     .. code-block:: console
 
-      $ pixi init my_hydromt_wflow
-      $ cd my_hydromt_wflow
-      $ pixi add hydromt_wflow
+      $ pixi init my_project
+      $ cd my_project
+      $ pixi add project
 
     .. note::
-      pixi resolves packages by default via conda-forge.
+      pixi resolves packages by default via conda-forge, if there are still unresolved packages it will try to use pypi.
       It is also possible to use pypi by calling :code:`pixi add --pypi hydromt_wflow`.
       We recommend to not mix conda-forge and pypi packages in the same environment, but it is possible.
 
@@ -147,13 +153,13 @@ The output should look similar to the example below:
             - gcs_cmip6_data (hydromt x.y.z)
         Uri_resolver plugins:
             - convention (hydromt x.y.z)
-            - raster_tindex (hydromt x.y.z)  
+            - raster_tindex (hydromt x.y.z)
 
 Installing optional dependencies
 --------------------------------
 
-HydroMT-Wflow provides several optional dependencies that extend its capabilities, 
-such as additional data sources or hydrological processing functions. 
+HydroMT-Wflow provides several optional dependencies that extend its capabilities,
+such as additional data sources or hydrological processing functions.
 
 Optional packages include:
 
@@ -191,7 +197,7 @@ Developer installation
 If you want to contribute to HydroMT-Wflow or modify its source code, see the
 :ref:`Developer installation guide <dev_env>`.
 
-To install the latest development version of HydroMT-Wflow, 
+To install the latest development version of HydroMT-Wflow,
 you can clone the repository and checkout the desired version tag:
 
 .. code-block:: console

--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -29,7 +29,7 @@ which avoids conflicts with other packages and allows you to have multiple versi
 They work differently to conda/pip, where the typical workflow is to activate a named environment first
 (for example with ``conda activate <env>``), and then run installation and CLI commands from that active environment.
 In uv and pixi, project environment management is tied to the project folder itself and is integrated into one tool-driven
-workflow and commands are typically run through the project tool (for example ``pixi run ...`` or ``uv run ...``).
+workflow and commands are typically run through the project tool (for example ``pixi run python my_script.py`` or ``uv run my_script.py``).
 
 
 Installing HydroMT-Wflow
@@ -54,7 +54,7 @@ Therefore we use uv or pixi to create a new project folder with Python directly 
 
       $ uv init my_project
       $ cd my_project
-      $ uv add project
+      $ uv add hydromt_wflow
       $ uv sync
 
     .. note::
@@ -68,7 +68,7 @@ Therefore we use uv or pixi to create a new project folder with Python directly 
 
       $ pixi init my_project
       $ cd my_project
-      $ pixi add project
+      $ pixi add hydromt_wflow
 
     .. note::
       pixi resolves packages by default via conda-forge, if there are still unresolved packages it will try to use pypi.

--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -14,109 +14,176 @@ We recommend installing HydroMT-Wflow in a dedicated Python environment to ensur
 Prerequisite: Python installation
 =================================
 
-You will need **Python 3.11 or newer** and a package/environment manager such as pip, conda, mamba or uv.
-These tools simplify installing packages and managing isolated environments.
+You will need **Python 3.11 or greater** and a package manager such as uv, pixi, or others in order to use HydroMT-Wflow. 
+These package managers help you to install (Python) packages and manage environments such that different installations do not conflict.
 
 If you do not yet have one installed, we recommend either:
 
-- `Miniconda <https://docs.conda.io/en/latest/miniconda.html>`_
-- `Miniforge (Mambaforge) <https://conda-forge.org/docs/>`_
-- `uv <https://docs.astral.sh/uv/>`_
+- `uv <https://docs.astral.sh/uv/>`_: uses `pypi.org <https://pypi.org>`_ for downloading dependencies.
+- `pixi <https://pixi.sh>`_: uses `conda-forge <https://conda-forge.org/>`_ for downloading dependencies.
 
-Both conda variants come preconfigured with the **conda-forge** channel, which provides free and open packages used by HydroMT.
+It is also possible to use other package managers, such as pip or conda.
+The benefits of uv and pixi over pip and conda are that they install Python directly in the project folder,
+which avoids conflicts with other packages and allows you to have multiple versions of Python installed on your system.
 
 Installing HydroMT-Wflow
 ========================
 
-HydroMT-Wflow is available from both **PyPI** and **conda-forge**.
-The simplest and most flexible approach is to install it using **pip** inside a new environment.
+HydroMT-Wflow is available from PyPI and conda-forge, and can be installed using uv, pixi, or others.
+Here we will describe the installation using **uv** and the **pixi** package manager.
 
-Installation in a conda environment using uv / pip
---------------------------------------------------
+Basic Installation
+------------------
 
-We recommend creating a clean environment to avoid dependency conflicts. For example:
+We strongly recommend installing HydroMT-Wflow in a separate environment to avoid conflicts with other packages.
+Therefore we use uv or pixi to create a new project folder with Python directly installed.
 
-.. code-block:: console
+.. tab-set::
+  :sync-group: package-manager
 
-    $ conda create -n hydromt-wflow uv python=3.13
-    $ conda activate hydromt-wflow
-    $ uv pip install hydromt_wflow
+  .. tab-item:: uv
+    :sync: uv
 
-This will install HydroMT-Wflow along with HydroMT core and all required dependencies.
+    .. code-block:: console
 
-To verify the installation, you can list the installed HydroMT plugins:
+      $ uv init my_hydromt_wflow
+      $ cd my_hydromt_wflow
+      $ uv add hydromt_wflow
+      $ uv sync
 
-.. code-block:: console
+    .. note::
+      If you want to develop a model plugin, we recommend running :code:`uv init` with the ``--library`` option,
+      which will create a library project instead of an application project.
 
-    $(hydromt-wflow) hydromt --plugins
+  .. tab-item:: pixi
+    :sync: pixi
+
+    .. code-block:: console
+
+      $ pixi init my_hydromt_wflow
+      $ cd my_hydromt_wflow
+      $ pixi add hydromt_wflow
+
+    .. note::
+      pixi resolves packages by default via conda-forge.
+      It is also possible to use pypi by calling :code:`pixi add --pypi hydromt_wflow`.
+      We recommend to not mix conda-forge and pypi packages in the same environment, but it is possible.
+
+To test whether the installation was successful, run :code:`uv run hydromt --plugins` on uv, or :code:`pixi run hydromt --plugins` on pixi.
+The output should look similar to the example below:
+
+.. tab-set::
+  :sync-group: package-manager
+
+  .. tab-item:: uv
+    :sync: uv
+
+    .. code-block:: console
+
+      $ uv run hydromt --plugins
         Model plugins:
-            - model (hydromt 1.3.0)
-            - wflow_sbm (hydromt_wflow 1.0.0)
-            - wflow_sediment (hydromt_wflow 1.0.0)
+            - model (hydromt x.y.z)
+            - wflow_sbm (hydromt_wflow x.y.z)
+            - wflow_sediment (hydromt_wflow x.y.z)
         Component plugins:
-            - ConfigComponent (hydromt 1.3.0)
-            - DatasetsComponent (hydromt 1.3.0)
-            - GeomsComponent (hydromt 1.3.0)
-            - GridComponent (hydromt 1.3.0)
-            - MeshComponent (hydromt 1.3.0)
-            - SpatialDatasetsComponent (hydromt 1.3.0)
-            - TablesComponent (hydromt 1.3.0)
-            - VectorComponent (hydromt 1.3.0)
+            - ConfigComponent (hydromt x.y.z)
+            - DatasetsComponent (hydromt x.y.z)
+            - GeomsComponent (hydromt x.y.z)
+            - GridComponent (hydromt x.y.z)
+            - MeshComponent (hydromt x.y.z)
+            - SpatialDatasetsComponent (hydromt x.y.z)
+            - TablesComponent (hydromt x.y.z)
+            - VectorComponent (hydromt x.y.z)
         Driver plugins:
-            - dataset_xarray (hydromt 1.3.0)
-            - geodataframe_table (hydromt 1.3.0)
-            - geodataset_vector (hydromt 1.3.0)
-            - geodataset_xarray (hydromt 1.3.0)
-            - pandas (hydromt 1.3.0)
-            - pyogrio (hydromt 1.3.0)
-            - raster_xarray (hydromt 1.3.0)
-            - rasterio (hydromt 1.3.0)
+            - dataset_xarray (hydromt x.y.z)
+            - geodataframe_table (hydromt x.y.z)
+            - geodataset_vector (hydromt x.y.z)
+            - geodataset_xarray (hydromt x.y.z)
+            - pandas (hydromt x.y.z)
+            - pyogrio (hydromt x.y.z)
+            - raster_xarray (hydromt x.y.z)
+            - rasterio (hydromt x.y.z)
         Catalog plugins:
-            - deltares_data (hydromt 1.3.0)
-            - artifact_data (hydromt 1.3.0)
-            - aws_data (hydromt 1.3.0)
-            - gcs_cmip6_data (hydromt 1.3.0)
+            - deltares_data (hydromt x.y.z)
+            - artifact_data (hydromt x.y.z)
+            - aws_data (hydromt x.y.z)
+            - gcs_cmip6_data (hydromt x.y.z)
         Uri_resolver plugins:
-            - convention (hydromt 1.3.0)
-            - raster_tindex (hydromt 1.3.0)
+            - convention (hydromt x.y.z)
+            - raster_tindex (hydromt x.y.z)
 
+  .. tab-item:: pixi
+    :sync: pixi
+
+    .. code-block:: console
+
+      $ pixi run hydromt --plugins
+        Model plugins:
+            - model (hydromt x.y.z)
+            - wflow_sbm (hydromt_wflow x.y.z)
+            - wflow_sediment (hydromt_wflow x.y.z)
+        Component plugins:
+            - ConfigComponent (hydromt x.y.z)
+            - DatasetsComponent (hydromt x.y.z)
+            - GeomsComponent (hydromt x.y.z)
+            - GridComponent (hydromt x.y.z)
+            - MeshComponent (hydromt x.y.z)
+            - SpatialDatasetsComponent (hydromt x.y.z)
+            - TablesComponent (hydromt x.y.z)
+            - VectorComponent (hydromt x.y.z)
+        Driver plugins:
+            - dataset_xarray (hydromt x.y.z)
+            - geodataframe_table (hydromt x.y.z)
+            - geodataset_vector (hydromt x.y.z)
+            - geodataset_xarray (hydromt x.y.z)
+            - pandas (hydromt x.y.z)
+            - pyogrio (hydromt x.y.z)
+            - raster_xarray (hydromt x.y.z)
+            - rasterio (hydromt x.y.z)
+        Catalog plugins:
+            - deltares_data (hydromt x.y.z)
+            - artifact_data (hydromt x.y.z)
+            - aws_data (hydromt x.y.z)
+            - gcs_cmip6_data (hydromt x.y.z)
+        Uri_resolver plugins:
+            - convention (hydromt x.y.z)
+            - raster_tindex (hydromt x.y.z)  
 
 Installing optional dependencies
 --------------------------------
 
-HydroMT-Wflow provides several optional dependencies that extend its capabilities, such as additional data sources or hydrological processing functions.
-You can install these easily using pip's extras syntax:
+HydroMT-Wflow provides several optional dependencies that extend its capabilities, 
+such as additional data sources or hydrological processing functions. 
 
-.. code-block:: console
-
-    $(hydromt-wflow) uv pip install "hydromt_wflow[extra]"
-
-This will install optional packages such as:
+Optional packages include:
 
 - **gwwapi** - provides access to Global Water Watch reservoir datasets.
 - **hydroengine** - enables integration with Google Earth Engine.
 - **wradlib** - provides radar rainfall processing and interpolation tools.
 - **pyet** - adds evapotranspiration computation support.
 
+To install these optional dependencies, you can use the following uv/pip commands:
+
+.. tab-set::
+  :sync-group: package-manager
+
+  .. tab-item:: uv
+    :sync: uv
+
+    .. code-block:: console
+
+      $ uv add "hydromt_wflow[docs]"
+      $ uv add "hydromt_wflow[examples]"
+      $ uv add "hydromt_wflow[extra]"
+      $ uv add "hydromt_wflow[test]"
+      $ uv add "hydromt_wflow[all]"
+
+  .. tab-item:: pixi
+    :sync: pixi
+
+    Not required, as pixi install via conda-forge, which contains all optional dependencies by default.
+
 For a list of all the optional dependency groups and their contents, have a look at the `pyproject.toml` file. Use `hydromt_wflow[all]` to install all optional dependencies.
-
-
-Installing via conda
---------------------
-
-HydroMT-Wflow is also available through the conda-forge channel. You can install it directly with:
-
-.. code-block:: console
-
-    $ conda create -n hydromt-wflow -c conda-forge hydromt_wflow
-    $ conda activate hydromt-wflow
-
-Note that some optional dependencies (e.g. ``gwwapi`` or ``hydroengine``) are only available through PyPI.
-You can install them afterwards with pip inside your conda environment:
-
-.. code-block:: console
-
-    $(hydromt-wflow) uv pip install "hydromt_wflow[extra]"
 
 Developer installation
 ======================
@@ -124,5 +191,10 @@ Developer installation
 If you want to contribute to HydroMT-Wflow or modify its source code, see the
 :ref:`Developer installation guide <dev_env>`.
 
-For development work, you can use either a Conda-based setup or **Pixi**, which provides a fully reproducible project environment.
-Pixi should be used only in developer installations — not for general users — since it manages dependencies project-locally and is less suited for managing multiple plugins globally.
+To install the latest development version of HydroMT-Wflow, 
+you can clone the repository and checkout the desired version tag:
+
+.. code-block:: console
+
+  $ git clone https://github.com/Deltares/hydromt_wflow.git
+  $ git checkout v<x.y.z>

--- a/docs/user_guide/5_setup_methods/setup_lulcmaps.rst
+++ b/docs/user_guide/5_setup_methods/setup_lulcmaps.rst
@@ -67,7 +67,7 @@ The columns names should match the HydroMT names of each Wflow parameter. These 
 - **soil_compacted_fraction**: The fraction of compacted or urban area per grid cell [-]
 - **vegetation_root_depth**: Length of vegetation roots [mm]
 - **vegetation_leaf_storage**: Specific leaf storage [mm]
-- **vegetation_wood_storage**: Fraction of wood in the vegetation/plant [-]
+- **vegetation_wood_storage**: Storage woody part of vegetation [mm]
 - **land_water_fraction**: The fraction of open water per grid cell [-]
 - **vegetation_crop_factor**: Crop coefficient [-]
 - **vegetation_feddes_alpha_h1**: Root water uptake reduction at soil water pressure head h1 (0 or 1) [-]

--- a/examples/wflow_build.yml
+++ b/examples/wflow_build.yml
@@ -64,7 +64,7 @@ steps:
       min_area: 0.0           # minimum glacier area to consider [km2]
 
   - setup_lulcmaps:
-      lulc_fn : globcover_2009     # source for lulc maps: {globcover, vito, corine}
+      lulc_fn : globcover     # source for lulc maps: {globcover, vito, corine}
       lulc_mapping_fn: globcover_mapping_default  # default mapping for lulc classes
 
   - setup_laimaps:

--- a/examples/wflow_build.yml
+++ b/examples/wflow_build.yml
@@ -64,7 +64,7 @@ steps:
       min_area: 0.0           # minimum glacier area to consider [km2]
 
   - setup_lulcmaps:
-      lulc_fn : globcover     # source for lulc maps: {globcover, vito, corine}
+      lulc_fn : globcover_2009    # source for lulc maps: {globcover, vito, corine}
       lulc_mapping_fn: globcover_mapping_default  # default mapping for lulc classes
 
   - setup_laimaps:

--- a/examples/wflow_update_water_demand.yml
+++ b/examples/wflow_update_water_demand.yml
@@ -51,9 +51,6 @@ steps:
         - 1
       cropland_class:
         - 11
-        - 14
-        - 20
-        - 30
       paddy_class:
         - 12
       area_threshold: 0.6

--- a/hydromt_wflow/wflow_base.py
+++ b/hydromt_wflow/wflow_base.py
@@ -790,7 +790,7 @@ and will soon be removed. '
         * **vegetation_leaf_storage** map:
             Specific leaf storage [mm]
         * **vegetation_wood_storage** map:
-            Fraction of wood in the vegetation/plant [-]
+            Storage woody part of vegetation [mm]
         * **vegetation_root_depth** map:
             Length of vegetation roots [mm]
         * **soil_compacted_fraction** map:
@@ -930,7 +930,7 @@ and will soon be removed. '
         * **vegetation_leaf_storage** map:
             Specific leaf storage [mm]
         * **vegetation_wood_storage** map:
-            Fraction of wood in the vegetation/plant [-]
+            Storage woody part of vegetation [mm]
         * **vegetation_root_depth** map:
             Length of vegetation roots [mm]
         * **soil_compacted_fraction** map:


### PR DESCRIPTION
## Issue addressed
Fixes #817, #814, #614

## Explanation
Changed the installation guide to be consistent with what is described in hydromt. Also corrected the description of vegetation_wood_storage and cropland classes in the water demand example

## Checklist
- [ ] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [ ] Tests & pre-commit hooks pass
- [x] Updated documentation if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
