### PR TITLE
feat: generate report difference plots for failing regression tests

### DIFF
--- a/tests/regression/.gitignore
+++ b/tests/regression/.gitignore
@@ -1,2 +1,3 @@
 .runs/
 system-test/
+.runs*/

--- a/tests/regression/README.md
+++ b/tests/regression/README.md
@@ -142,10 +142,14 @@ Commit the updated files together with the code change that caused the deviation
 When the assertion step fails, the test output explains what exceeded tolerance and
 lists three follow-up options:
 
-1. **Fix the regression** — identify the code change that shifted the output, correct it,
+1. **Visualize and inspect the difference** — if there are any failures, plots of
+   actual vs. baseline metrics and the underlying output time series will by
+   default be created at ``tests/regression/.runs/reports/<basin>.png``.
+
+2. **Fix the regression** — identify the code change that shifted the output, correct it,
    re-run the pipeline, and verify the metrics pass.
 
-2. **Accept the change and regenerate** — if the deviation is expected (e.g. a deliberate
+3. **Accept the change and regenerate** — if the deviation is expected (e.g. a deliberate
    model improvement), regenerate the baseline metrics and commit the updated JSON files:
 
    ```bash
@@ -154,7 +158,7 @@ lists three follow-up options:
 
    Re-run the assertion to confirm the new baseline passes.
 
-3. **Widen tolerances** — if the deviation is within acceptable physical bounds but
+4. **Widen tolerances** — if the deviation is within acceptable physical bounds but
    exceeds the current threshold, update `rel_tol` / `abs_tol` in
    `tests/regression/<basin>/config.json`.
 

--- a/tests/regression/regression_utils.py
+++ b/tests/regression/regression_utils.py
@@ -4,7 +4,6 @@ import json
 import math
 import shutil
 import subprocess
-import tempfile
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -429,7 +428,7 @@ def report_failures(failures: list[str]) -> str:
     underlying output time series) without re-building or re-running any
     model, use `plot_regression_report`, e.g.:
         from tests.regression.regression_utils import plot_regression_report
-        plot_regression_report("<basin>", save_path=Path("report.png"))
+        plot_regression_report("<basin>")
     See also `build_regression_check`, `plot_metric_comparison` and
     `plot_metric_timeseries` for lower-level building blocks.
     """
@@ -460,7 +459,7 @@ def report_failures(failures: list[str]) -> str:
         "  4. Visualize: Plot actual vs. baseline metrics and the underlying output",
         "     time series (reads existing outputs, does not re-run anything):",
         "       from tests.regression.regression_utils import plot_regression_report",
-        "       plot_regression_report('<basin>', save_path=Path('report.png'))",
+        "       plot_regression_report('<basin>')",
         "",
     ]
     return "\n".join(lines)
@@ -674,15 +673,10 @@ def plot_regression_report(
     fig.suptitle(f"Regression report: {basin}")
     fig.tight_layout()
 
-    if save_path is not None:
-        if save_path.exists():
-            save_path = (
-                Path(tempfile.gettempdir())
-                / "wflow_regression"
-                / f"{save_path.stem}_{int(time.time())}.png"
-            )
-            save_path.parent.mkdir(parents=True, exist_ok=True)
-        fig.savefig(str(save_path), dpi=150)
-        print(f"Regression report saved to {save_path}")
+    if save_path is None:
+        save_path = run_root / "reports" / f"{basin}.png"
+    save_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(str(save_path), dpi=150)
+    print(f"Regression report saved to {save_path}")
 
     return fig

--- a/tests/regression/regression_utils.py
+++ b/tests/regression/regression_utils.py
@@ -4,14 +4,18 @@ import json
 import math
 import shutil
 import subprocess
+import tempfile
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal
 
+import matplotlib.pyplot as plt
 import numpy as np
 import xarray as xr
 import yaml
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
 
 _DEFAULT_REL_TOL_METRIC = 1e-3  # 0.1%
 _DEFAULT_ABS_TOL_METRIC = 1e-6  # 1e-6 (for near-zero values)
@@ -275,12 +279,13 @@ def run_wflow(wflow_cli: Path, config_toml: Path) -> float:
     return elapsed
 
 
-def _to_series(
+def _select_and_reduce(
     data_array: xr.DataArray,
     selector: dict[str, float] | None,
     selector_method: str,
     aggregation: str,
-) -> np.ndarray:
+) -> xr.DataArray:
+    """Apply the selector and reduce non-time dims, keeping the time series intact."""
     data = data_array
     if selector:
         if selector_method == "sel":
@@ -300,6 +305,16 @@ def _to_series(
             data = data.max(dim=reduce_dims, skipna=True)
         else:
             raise ValueError(f"Unsupported aggregation: {aggregation}")
+    return data
+
+
+def _to_series(
+    data_array: xr.DataArray,
+    selector: dict[str, float] | None,
+    selector_method: str,
+    aggregation: str,
+) -> np.ndarray:
+    data = _select_and_reduce(data_array, selector, selector_method, aggregation)
     values = np.asarray(data.values, dtype=float)
     if values.ndim == 0:
         values = values.reshape(1)
@@ -408,8 +423,22 @@ def compare_metrics(check: RegressionCheck) -> list[str]:
 
 
 def report_failures(failures: list[str]) -> str:
+    """Build a human-readable failure report.
+
+    To visualize a failing run (actual vs. baseline bar charts plus the
+    underlying output time series) without re-building or re-running any
+    model, use `plot_regression_report`, e.g.:
+        from tests.regression.regression_utils import plot_regression_report
+        plot_regression_report("<basin>", save_path=Path("report.png"))
+    See also `build_regression_check`, `plot_metric_comparison` and
+    `plot_metric_timeseries` for lower-level building blocks.
+    """
     n = len(failures)
-    lines = [f"Regression check failed: {n} metric(s) failed.", "", "Failures:"]
+    lines = [
+        f"Regression check failed: {n} metric(s) failed.",
+        "",
+        "Failures:",
+    ]
     for f in failures:
         lines.append(f"  {f}")
     lines += [
@@ -427,6 +456,12 @@ def report_failures(failures: list[str]) -> str:
         "  3. Widen tolerances: If the deviation is within acceptable bounds but exceeds",
         "     the current thresholds, update rel_tol / abs_tol in the relevant",
         "     tests/regression/<basin>/config.json and regenerate metrics.",
+        "",
+        "  4. Visualize: Plot actual vs. baseline metrics and the underlying output",
+        "     time series (reads existing outputs, does not re-run anything):",
+        "       from tests.regression.regression_utils import plot_regression_report",
+        "       plot_regression_report('<basin>', save_path=Path('report.png'))",
+        "",
     ]
     return "\n".join(lines)
 
@@ -441,3 +476,213 @@ def emit_teamcity_stats(
             print(
                 f"##teamcity[buildStatisticValue key='{safe_key}' value='{value:.6e}']"
             )
+
+
+def build_regression_check(
+    project_root: Path,
+    run_root: Path,
+    basin: str,
+    model_type: Literal["sbm", "sediment"],
+) -> RegressionCheck:
+    """Build a RegressionCheck for an already-completed run.
+
+    Reads the existing model output netcdf, baseline metrics and recorded
+    runtimes from disk without building or running any model.
+    """
+    basin_config = load_basin_config(project_root, basin)
+    model_cfg = basin_config[model_type]
+    baseline_path = resolve_path(project_root, basin_config["baseline_metrics"])
+    baseline = json.loads(baseline_path.read_text(encoding="utf-8"))
+
+    output_nc = run_root / f"wflow_{model_type}" / basin / model_cfg["output_nc"]
+    specs = [Metric.from_dict(m) for m in model_cfg["metrics"]]
+    actual = compute_metrics(output_nc, specs)
+
+    runtimes_actual: dict[str, float] = {}
+    runtimes_path = run_root / "runtimes.json"
+    if runtimes_path.exists():
+        all_runtimes = json.loads(runtimes_path.read_text(encoding="utf-8"))
+        runtimes_actual = all_runtimes.get(basin, {}).get(model_type, {})
+
+    runtime_specs = {
+        k: RuntimeSpec.from_dict(v)
+        for k, v in model_cfg.get("runtime_specs", {}).items()
+    }
+
+    return RegressionCheck(
+        basin=basin,
+        model_type=model_type,
+        metrics=MetricsComparison(
+            actual=actual,
+            baseline=baseline.get(model_type, {}),
+            specs=specs,
+        ),
+        runtimes=RuntimesComparison(
+            actual=runtimes_actual,
+            baseline=baseline.get(f"{model_type}_runtimes", {}),
+            specs=runtime_specs,
+        ),
+    )
+
+
+def plot_metric_comparison(check: RegressionCheck, ax: Axes | None = None) -> Axes:
+    """Bar plot comparing actual vs. baseline metric values for a RegressionCheck.
+
+    Actual bars are colored red when the observed value is outside the
+    metric's rel_tol/abs_tol relative to baseline, blue otherwise. Each pair
+    of bars is annotated with the relative error. A log y-scale is used since
+    mean/peak/total values for a metric can differ by orders of magnitude.
+    """
+    labels: list[str] = []
+    actual_vals: list[float] = []
+    baseline_vals: list[float] = []
+    rel_errs: list[float] = []
+    failed: list[bool] = []
+
+    for spec in check.metrics.specs:
+        baseline_group = check.metrics.baseline.get(spec.name, {})
+        actual_group = check.metrics.actual.get(spec.name, {})
+        for metric_key in spec.metrics:
+            expected = baseline_group.get(metric_key)
+            observed = actual_group.get(metric_key)
+            if expected is None or observed is None:
+                continue
+            expected = float(expected)
+            observed = float(observed)
+            abs_err = abs(observed - expected)
+            rel_err = abs_err / abs(expected) if expected != 0 else float("nan")
+            if abs(expected) <= spec.abs_tol:
+                is_failed = abs_err > spec.abs_tol
+            else:
+                is_failed = rel_err > spec.rel_tol
+            labels.append(f"{spec.name}\n{metric_key}")
+            actual_vals.append(observed)
+            baseline_vals.append(expected)
+            rel_errs.append(rel_err)
+            failed.append(is_failed)
+
+    if ax is None:
+        _, ax = plt.subplots(figsize=(max(6, len(labels) * 1.2), 4))
+
+    x = np.arange(len(labels))
+    width = 0.35
+    ax.bar(x - width / 2, baseline_vals, width, label="baseline", color="tab:grey")
+    bars = ax.bar(
+        x + width / 2,
+        actual_vals,
+        width,
+        label="actual",
+        color=["tab:red" if f else "tab:blue" for f in failed],
+    )
+    if all(v > 0 for v in (*baseline_vals, *actual_vals)):
+        ax.set_yscale("log")
+    for bar, rel_err in zip(bars, rel_errs):
+        if math.isnan(rel_err):
+            continue
+        ax.annotate(
+            f"{rel_err:+.1%}",
+            xy=(bar.get_x() + bar.get_width() / 2, bar.get_height()),
+            xytext=(0, 3),
+            textcoords="offset points",
+            ha="center",
+            va="bottom",
+            fontsize=8,
+        )
+    ax.set_xticks(x)
+    ax.set_xticklabels(labels, rotation=45, ha="right")
+    ax.set_ylabel("Value")
+    ax.set_title(f"{check.basin} - {check.model_type} metrics (red = out of tolerance)")
+    ax.legend()
+    return ax
+
+
+def plot_metric_timeseries(
+    output_nc: Path,
+    specs: list[Metric],
+    axes: list[Axes] | None = None,
+) -> list[Axes]:
+    """Plot, per metric spec, the (spatially-reduced) time series it was computed from."""
+    if axes is None:
+        _, axes_arr = plt.subplots(
+            len(specs), 1, figsize=(10, 3 * len(specs)), squeeze=False
+        )
+        axes = list(axes_arr[:, 0])
+
+    with xr.open_dataset(output_nc) as dataset:
+        for ax, spec in zip(axes, specs):
+            if spec.variable not in dataset:
+                raise KeyError(f"Variable '{spec.variable}' not found in {output_nc}")
+            series = _select_and_reduce(
+                data_array=dataset[spec.variable],
+                selector=spec.selector,
+                selector_method=spec.selector_method,
+                aggregation=spec.aggregation,
+            ).load()
+            if "time" in series.dims:
+                series.plot.line(ax=ax, x="time")
+            else:
+                ax.plot(series.values)
+            ax.set_title(f"{spec.name} ({spec.variable})")
+            ax.set_ylabel(spec.variable)
+
+    return axes
+
+
+def plot_regression_report(
+    basin: str,
+    run_root: Path | None = None,
+    project_root: Path | None = None,
+    save_path: Path | None = None,
+) -> Figure:
+    """Visualize regression metrics and their underlying time series for one basin.
+
+    Reads the existing model outputs (sbm and sediment) and baseline metrics
+    from disk; does not build or run any model. For each model type, plots a
+    bar chart comparing actual vs. baseline metric values plus line plots of
+    the time series each metric was computed from.
+    """
+    project_root = project_root or repo_root()
+    run_root = run_root or default_run_root()
+    basin_config = load_basin_config(project_root, basin)
+
+    sbm_check = build_regression_check(project_root, run_root, basin, "sbm")
+    sediment_check = build_regression_check(project_root, run_root, basin, "sediment")
+
+    sbm_output = run_root / "wflow_sbm" / basin / basin_config["sbm"]["output_nc"]
+    sediment_output = (
+        run_root / "wflow_sediment" / basin / basin_config["sediment"]["output_nc"]
+    )
+
+    n_ts_rows = max(len(sbm_check.metrics.specs), len(sediment_check.metrics.specs))
+    fig, axes = plt.subplots(1 + n_ts_rows, 2, figsize=(14, 3.5 * (1 + n_ts_rows)))
+
+    plot_metric_comparison(sbm_check, ax=axes[0, 0])
+    plot_metric_comparison(sediment_check, ax=axes[0, 1])
+
+    plot_metric_timeseries(sbm_output, sbm_check.metrics.specs, axes=list(axes[1:, 0]))
+    plot_metric_timeseries(
+        sediment_output, sediment_check.metrics.specs, axes=list(axes[1:, 1])
+    )
+
+    # Hide unused time series rows for the model type with fewer metrics.
+    for row in range(1, 1 + n_ts_rows):
+        if row > len(sbm_check.metrics.specs):
+            axes[row, 0].set_visible(False)
+        if row > len(sediment_check.metrics.specs):
+            axes[row, 1].set_visible(False)
+
+    fig.suptitle(f"Regression report: {basin}")
+    fig.tight_layout()
+
+    if save_path is not None:
+        if save_path.exists():
+            save_path = (
+                Path(tempfile.gettempdir())
+                / "wflow_regression"
+                / f"{save_path.stem}_{int(time.time())}.png"
+            )
+            save_path.parent.mkdir(parents=True, exist_ok=True)
+        fig.savefig(str(save_path), dpi=150)
+        print(f"Regression report saved to {save_path}")
+
+    return fig

--- a/tests/regression/test_regression.py
+++ b/tests/regression/test_regression.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+from hydromt_wflow import __version__
 from tests.regression.regression_utils import (
     Metric,
     MetricsComparison,
@@ -19,6 +20,7 @@ from tests.regression.regression_utils import (
     emit_teamcity_stats,
     get_basins_for_profile,
     load_basin_config,
+    plot_regression_report,
     repo_root,
     report_failures,
     resolve_path,
@@ -137,4 +139,8 @@ def test_basin_regression_metrics(basin, request):
     )
 
     report = report_failures(failures)
+    if failures:
+        plot_regression_report(
+            basin=basin, save_path=Path(__file__).parent / f"report_{__version__}.png"
+        )
     assert not failures, report

--- a/tests/regression/test_regression.py
+++ b/tests/regression/test_regression.py
@@ -7,7 +7,6 @@ from pathlib import Path
 
 import pytest
 
-from hydromt_wflow import __version__
 from tests.regression.regression_utils import (
     Metric,
     MetricsComparison,
@@ -140,7 +139,5 @@ def test_basin_regression_metrics(basin, request):
 
     report = report_failures(failures)
     if failures:
-        plot_regression_report(
-            basin=basin, save_path=Path(__file__).parent / f"report_{__version__}.png"
-        )
+        plot_regression_report(basin=basin)
     assert not failures, report


### PR DESCRIPTION
## Explanation
While investigating broken regression tests for https://github.com/Deltares/hydromt_wflow/pull/832, did this work and thought it would be nice to have in main as well, not just as a script on my machine. 


