### PR TITLE
finalize release v1.1.0 

### DIFF
--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -90,6 +90,17 @@
     "url": "https://deltares.github.io/hydromt_wflow/v1.0.1/"
   },
   {
+    "name": "v1.0.2",
+    "version": "v1.0.2",
+    "url": "https://deltares.github.io/hydromt_wflow/v1.0.2/"
+  },
+  {
+    "name": "v1.1.0",
+    "version": "v1.1.0",
+    "url": "https://deltares.github.io/hydromt_wflow/v1.1.0/"
+  },
+  {
+    "preferred": true,
     "name": "stable",
     "version": "stable",
     "url": "https://deltares.github.io/hydromt_wflow/stable/"

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,21 @@ The format is based on `Keep a Changelog`_, and this project adheres to
 
 Unreleased
 ==========
+
+Added
+-----
+
+Fixed
+-----
+
+Removed
+-------
+
+Changed
+-------
+
+v1.1.0 (18 August 2026)
+=======================
 Added
 -----
 - **setup_agroforestry**: method to add agroforestry areas to landuse maps and update related vegetation parameters. PR #2

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,8 +6,9 @@ import sys
 import hydromt_wflow
 
 # URL to the switcher.json file for version switching in the docs. See https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/version-dropdown.html
-# This should point to a stable URL where the switcher.json file is hosted. (e.g. the static files of the latest published docs build)
-SWITCHER_JSON_URL = "https://raw.githubusercontent.com/Deltares/hydromt_wflow/gh-pages/switcher.json"
+# Points at the "latest" (dev) build's copy of docs/_static/switcher.json, which docs.yml
+# redeploys on every push to main, so new releases only need an entry added here, no gh-pages edits.
+SWITCHER_JSON_URL = "https://deltares.github.io/hydromt_wflow/latest/_static/switcher.json"
 
 # -- Path setup --------------------------------------------------------------
 DOCS_ROOT = Path(__file__).parent.resolve()


### PR DESCRIPTION
- update changelog, switcher and conf.py.

- also updated the stable symlink manually on the gh-pages branch

- Went over the release form and checked all fields and links: `Stichting Deltares\Product line Hydrology - Documents\General\5. Operational\Software Release Forms\HydroMT\HydroMT-wflow Software Release Form v1.1.0.docx`